### PR TITLE
Tmux integration

### DIFF
--- a/cmd/ssh-x-term/main.go
+++ b/cmd/ssh-x-term/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"ssh-x-term/internal/config"
@@ -10,7 +11,37 @@ import (
 )
 
 func main() {
-	// Initialize config manager
+	if os.Getenv("TMUX") == "" {
+		fmt.Println("Not in tmux session. Attempting to launch inside tmux...")
+
+		execPath, err := os.Executable()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting executable path: %v\n", err)
+			os.Exit(1)
+		}
+
+		args := os.Args[1:]
+		tmuxArgs := append([]string{"new-session", execPath}, args...)
+		cmd := exec.Command("tmux", tmuxArgs...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to start tmux session: %v\nFalling back to normal execution...\n", err)
+			config.IsTmuxAvailable = false
+			runApp()
+			return
+		}
+
+		return
+	}
+
+	config.IsTmuxAvailable = true
+	runApp()
+}
+
+func runApp() {
 	configManager, err := config.NewConfigManager()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing config: %v\n", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,8 @@ type ConfigManager struct {
 	Config     *Config
 }
 
+var IsTmuxAvailable bool = false
+
 // NewConfigManager creates a new configuration manager
 func NewConfigManager() (*ConfigManager, error) {
 	homeDir, err := os.UserHomeDir()

--- a/internal/ui/components/connection_list.go
+++ b/internal/ui/components/connection_list.go
@@ -62,7 +62,11 @@ func NewConnectionList(connections []config.SSHConnection) *ConnectionList {
 
 	// Set up list
 	l := list.New(items, list.NewDefaultDelegate(), 0, 0)
-	l.Title = "SSH Connections"
+	if config.IsTmuxAvailable {
+		l.Title = "SSH Connections - Toggle open in new terminal [x]"
+	} else {
+		l.Title = "SSH Connections - Toggle open in new terminal [ ]"
+	}
 	l.SetShowStatusBar(false)
 	l.SetFilteringEnabled(true)
 	l.Styles.Title = titleStyle
@@ -100,7 +104,7 @@ func NewConnectionList(connections []config.SSHConnection) *ConnectionList {
 		list:              l,
 		connections:       connections,
 		highlightedConn:   highlighted,
-		openInNewTerminal: false, // Default state of the checkbox
+		openInNewTerminal: config.IsTmuxAvailable, // Default state of the checkbox
 	}
 }
 
@@ -146,7 +150,7 @@ func (cl *ConnectionList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if cl.openInNewTerminal {
 				checkboxStr = "[x]"
 			}
-			cl.list.Title = fmt.Sprintf("SSH Connections - ToggleOpenInNewTerminal %s", checkboxStr)
+			cl.list.Title = fmt.Sprintf("SSH Connections - Toggle open in new terminal %s", checkboxStr)
 		}
 	}
 


### PR DESCRIPTION
Start application in tmux session, if no session is opened yet, open a new one, if tmux is not available, fallback to basic implementation PTY. When tmux is available, the new windows will be named based on the connection user@hostname:port - Connection Name to easily navigate throught them, knowing exactly which connection you desire to change to.