### PR TITLE
3 bitwarden integration

### DIFF
--- a/cmd/ssh-x-term/main.go
+++ b/cmd/ssh-x-term/main.go
@@ -55,7 +55,7 @@ func runApp() {
 	}
 
 	// Create UI model
-	model := ui.NewModel(configManager)
+	model := ui.NewModel()
 
 	// Initialize the Bubble Tea program
 	p := tea.NewProgram(

--- a/internal/config/bitwarden.go
+++ b/internal/config/bitwarden.go
@@ -1,0 +1,59 @@
+package config
+
+import ()
+
+// BitwardenConfig holds config for authentication (add fields as needed)
+type BitwardenConfig struct {
+	ServerURL string
+	Email     string
+	// Add OAuth tokens/password fields as needed
+	AccessToken string
+}
+
+// BitwardenManager implements Storage backed by Bitwarden API.
+type BitwardenManager struct {
+	Config *BitwardenConfig
+	// Add internal cache/mapping if needed
+}
+
+// NewBitwardenManager returns a Bitwarden storage backend.
+func NewBitwardenManager(cfg *BitwardenConfig) (*BitwardenManager, error) {
+	// Authenticate here (OAuth or password fallback)
+	// Save access token to cfg.AccessToken
+	return &BitwardenManager{
+		Config: cfg,
+	}, nil
+}
+
+func (b *BitwardenManager) Load() error {
+	// Optionally cache/fetch all items on startup
+	// Or always use API for live listing
+	return nil
+}
+
+func (b *BitwardenManager) Save() error {
+	// Not needed for Bitwarden – CRUD is live.
+	return nil
+}
+
+func (b *BitwardenManager) AddConnection(conn SSHConnection) error {
+	// Use Bitwarden API to create/update an item.
+	// return errors.New("Bitwarden AddConnection not implemented")
+	return nil
+}
+
+func (b *BitwardenManager) DeleteConnection(id string) error {
+	// Use Bitwarden API to delete the item by ID.
+	// return errors.New("Bitwarden DeleteConnection not implemented")
+	return nil
+}
+
+func (b *BitwardenManager) GetConnection(id string) (SSHConnection, bool) {
+	// Use Bitwarden API to fetch item by ID.
+	return SSHConnection{}, false
+}
+
+func (b *BitwardenManager) ListConnections() []SSHConnection {
+	// Use Bitwarden API to list and map items to SSHConnection.
+	return nil
+}

--- a/internal/config/bitwarden.go
+++ b/internal/config/bitwarden.go
@@ -1,59 +1,305 @@
 package config
 
-import ()
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+)
 
-// BitwardenConfig holds config for authentication (add fields as needed)
 type BitwardenConfig struct {
 	ServerURL string
 	Email     string
-	// Add OAuth tokens/password fields as needed
-	AccessToken string
 }
 
-// BitwardenManager implements Storage backed by Bitwarden API.
 type BitwardenManager struct {
-	Config *BitwardenConfig
-	// Add internal cache/mapping if needed
+	cfg        *BitwardenConfig
+	session    string
+	authed     bool
+	vaultMutex sync.Mutex // thread safety
+	items      map[string]SSHConnection
 }
 
-// NewBitwardenManager returns a Bitwarden storage backend.
+const sshNoteTagField = "ssh-x-term"
+
 func NewBitwardenManager(cfg *BitwardenConfig) (*BitwardenManager, error) {
-	// Authenticate here (OAuth or password fallback)
-	// Save access token to cfg.AccessToken
 	return &BitwardenManager{
-		Config: cfg,
+		cfg:   cfg,
+		items: make(map[string]SSHConnection),
 	}, nil
 }
 
-func (b *BitwardenManager) Load() error {
-	// Optionally cache/fetch all items on startup
-	// Or always use API for live listing
+// checkBwCLI checks if the 'bw' CLI is available in the PATH.
+func checkBwCLI() error {
+	_, err := exec.LookPath("bw")
+	if err != nil {
+		return errors.New("Bitwarden CLI (`bw`) is not installed or not in your PATH. Please install it: https://bitwarden.com/help/cli/")
+	}
 	return nil
 }
 
-func (b *BitwardenManager) Save() error {
-	// Not needed for Bitwarden – CRUD is live.
+// https://api.bitwarden.com default login URL
+func (bwm *BitwardenManager) Login(password, otp string) error {
+	if err := checkBwCLI(); err != nil {
+		fmt.Println(err)
+		return err
+	}
+	args := []string{"login", bwm.cfg.Email, password, "--raw"}
+	if bwm.cfg.ServerURL != "" {
+		args = append(args, "--server", bwm.cfg.ServerURL)
+	}
+	if otp != "" {
+		args = append(args, "--code", otp)
+	}
+	cmd := exec.Command("bw", args...)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		fmt.Printf("Bitwarden login failed: %s\n", stderr.String())
+		return fmt.Errorf("Bitwarden login failed: %s", stderr.String())
+	}
+	bwm.session = strings.TrimSpace(out.String())
+	bwm.authed = true
 	return nil
 }
 
-func (b *BitwardenManager) AddConnection(conn SSHConnection) error {
-	// Use Bitwarden API to create/update an item.
-	// return errors.New("Bitwarden AddConnection not implemented")
+func (bwm *BitwardenManager) Unlock(password string) error {
+	if err := checkBwCLI(); err != nil {
+		fmt.Println(err)
+		return err
+	}
+	cmd := exec.Command("bw", "unlock", password, "--raw")
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		fmt.Printf("Bitwarden unlock failed: %s\n", stderr.String())
+		return fmt.Errorf("Bitwarden unlock failed: %s", stderr.String())
+	}
+	bwm.session = strings.TrimSpace(out.String())
+	bwm.authed = true
 	return nil
 }
 
-func (b *BitwardenManager) DeleteConnection(id string) error {
-	// Use Bitwarden API to delete the item by ID.
-	// return errors.New("Bitwarden DeleteConnection not implemented")
+func (bwm *BitwardenManager) SessionKey() (string, error) {
+	if !bwm.authed || bwm.session == "" {
+		return "", fmt.Errorf("Bitwarden session is not authenticated")
+	}
+	return bwm.session, nil
+}
+
+// ---- Storage Interface Implementation ----
+
+// Load fetches all SSH connections from Bitwarden
+func (bwm *BitwardenManager) Load() error {
+	bwm.vaultMutex.Lock()
+	defer bwm.vaultMutex.Unlock()
+
+	session, err := bwm.SessionKey()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("bw", "list", "items", "--search", sshNoteTagField, "--session", session)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("bw list items failed: %s", stderr.String())
+	}
+
+	var items []map[string]interface{}
+	if err := json.Unmarshal(out.Bytes(), &items); err != nil {
+		return err
+	}
+
+	bwm.items = make(map[string]SSHConnection)
+	for _, item := range items {
+		if notes, ok := item["notes"].(string); ok && notes != "" {
+			conn := SSHConnection{}
+			if err := json.Unmarshal([]byte(notes), &conn); err == nil {
+				if id, ok := item["id"].(string); ok {
+					conn.ID = id
+				}
+				bwm.items[conn.ID] = conn
+			}
+		}
+	}
 	return nil
 }
 
-func (b *BitwardenManager) GetConnection(id string) (SSHConnection, bool) {
-	// Use Bitwarden API to fetch item by ID.
-	return SSHConnection{}, false
+// Save is a no-op for Bitwarden (all changes go through CLI immediately)
+func (bwm *BitwardenManager) Save() error {
+	return nil
 }
 
-func (b *BitwardenManager) ListConnections() []SSHConnection {
-	// Use Bitwarden API to list and map items to SSHConnection.
+// AddConnection creates a new SSH connection
+func (bwm *BitwardenManager) AddConnection(conn SSHConnection) error {
+	bwm.vaultMutex.Lock()
+	defer bwm.vaultMutex.Unlock()
+
+	session, err := bwm.SessionKey()
+	if err != nil {
+		return err
+	}
+	connBytes, err := json.Marshal(conn)
+	if err != nil {
+		return err
+	}
+	item := map[string]interface{}{
+		"type":  2, // Secure Note
+		"name":  conn.Name,
+		"notes": string(connBytes),
+		"tags":  []string{sshNoteTagField},
+	}
+	itemBytes, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("bw", "create", "item", "--session", session)
+	cmd.Stdin = bytes.NewReader(itemBytes)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to create Bitwarden item: %s", stderr.String())
+	}
+	// Optionally reload items to update the internal map
+	_ = bwm.Load()
 	return nil
+}
+
+// DeleteConnection removes a connection by Bitwarden item ID
+func (bwm *BitwardenManager) DeleteConnection(id string) error {
+	bwm.vaultMutex.Lock()
+	defer bwm.vaultMutex.Unlock()
+
+	session, err := bwm.SessionKey()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("bw", "delete", "item", id, "--session", session, "--permanent")
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("could not delete Bitwarden item: %s", stderr.String())
+	}
+	delete(bwm.items, id)
+	return nil
+}
+
+// GetConnection returns a connection by ID
+func (bwm *BitwardenManager) GetConnection(id string) (SSHConnection, bool) {
+	bwm.vaultMutex.Lock()
+	defer bwm.vaultMutex.Unlock()
+	c, ok := bwm.items[id]
+	return c, ok
+}
+
+// ListConnections returns all connections
+func (bwm *BitwardenManager) ListConnections() []SSHConnection {
+	bwm.vaultMutex.Lock()
+	defer bwm.vaultMutex.Unlock()
+	conns := make([]SSHConnection, 0, len(bwm.items))
+	for _, c := range bwm.items {
+		conns = append(conns, c)
+	}
+	return conns
+}
+
+// EditConnection updates an existing SSH connection (not part of Storage interface, but useful)
+func (bwm *BitwardenManager) EditConnection(conn SSHConnection) error {
+	bwm.vaultMutex.Lock()
+	defer bwm.vaultMutex.Unlock()
+
+	session, err := bwm.SessionKey()
+	if err != nil {
+		return err
+	}
+	if conn.ID == "" {
+		return fmt.Errorf("missing Bitwarden item ID for edit")
+	}
+	connBytes, err := json.Marshal(conn)
+	if err != nil {
+		return err
+	}
+	// Fetch current item
+	cmdGet := exec.Command("bw", "get", "item", conn.ID, "--session", session)
+	var outGet, errGet bytes.Buffer
+	cmdGet.Stdout = &outGet
+	cmdGet.Stderr = &errGet
+	if err := cmdGet.Run(); err != nil {
+		return fmt.Errorf("could not fetch Bitwarden item: %s", errGet.String())
+	}
+	var item map[string]interface{}
+	if err := json.Unmarshal(outGet.Bytes(), &item); err != nil {
+		return err
+	}
+	item["notes"] = string(connBytes)
+	item["name"] = conn.Name
+	if tags, ok := item["tags"].([]interface{}); ok {
+		found := false
+		for _, tag := range tags {
+			if tag.(string) == sshNoteTagField {
+				found = true
+				break
+			}
+		}
+		if !found {
+			item["tags"] = append(tags, sshNoteTagField)
+		}
+	} else {
+		item["tags"] = []string{sshNoteTagField}
+	}
+	itemBytes, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+	cmdEdit := exec.Command("bw", "edit", "item", conn.ID, "--session", session)
+	cmdEdit.Stdin = bytes.NewReader(itemBytes)
+	var outEdit, errEdit bytes.Buffer
+	cmdEdit.Stdout = &outEdit
+	cmdEdit.Stderr = &errEdit
+	if err := cmdEdit.Run(); err != nil {
+		return fmt.Errorf("could not edit Bitwarden item: %s", errEdit.String())
+	}
+	// Optionally reload items
+	_ = bwm.Load()
+	return nil
+}
+
+func (bwm *BitwardenManager) Status() (loggedIn bool, unlocked bool, err error) {
+	if err := checkBwCLI(); err != nil {
+		return false, false, err
+	}
+	cmd := exec.Command("bw", "status")
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return false, false, fmt.Errorf("bw status failed: %s", stderr.String())
+	}
+	type bwStatus struct {
+		Status string `json:"status"`
+	}
+	var stat bwStatus
+	if err := json.Unmarshal(out.Bytes(), &stat); err != nil {
+		return false, false, err
+	}
+	switch stat.Status {
+	case "unauthenticated":
+		return false, false, nil
+	case "locked":
+		return true, false, nil
+	case "unlocked":
+		return true, true, nil
+	}
+	return false, false, fmt.Errorf("unknown Bitwarden status: %s", stat.Status)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,6 @@ const (
 	defaultConfigFileName = "ssh-x-term.json"
 )
 
-// ConfigManager implements the Storage interface for local file storage.
 type ConfigManager struct {
 	ConfigPath string
 	Config     *Config
@@ -21,7 +20,6 @@ type ConfigManager struct {
 
 var IsTmuxAvailable bool = false
 
-// NewConfigManager creates a new Config instance with default values.
 func NewConfigManager() (*ConfigManager, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -46,7 +44,7 @@ func (cm *ConfigManager) Load() error {
 	data, err := os.ReadFile(cm.ConfigPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil // Config file doesn't exist, use defaults
+			return nil
 		}
 		return fmt.Errorf("failed to read config file: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,16 @@ func (cm *ConfigManager) Save() error {
 	return nil
 }
 
+func (cm *ConfigManager) EditConnection(conn SSHConnection) error {
+	for i, existing := range cm.Config.Connections {
+		if existing.ID == conn.ID {
+			cm.Config.Connections[i] = conn
+			return cm.Save()
+		}
+	}
+	return fmt.Errorf("connection with ID %s not found", conn.ID)
+}
+
 func (cm *ConfigManager) AddConnection(conn SSHConnection) error {
 	for i, existing := range cm.Config.Connections {
 		if existing.ID == conn.ID {

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -7,14 +7,13 @@ type SSHConnection struct {
 	Host        string `json:"host"`
 	Port        int    `json:"port"`
 	Username    string `json:"username"`
-	Password    string `json:"password,omitempty"`   // If use_password: password, if keyfile: private key content
-	PublicKey   string `json:"public_key,omitempty"` // Public key content
+	Password    string `json:"password,omitempty"`
+	PublicKey   string `json:"public_key,omitempty"`
 	UsePassword bool   `json:"use_password"`
-	KeyFile     string `json:"key_file,omitempty"` // Path or original file, not used for Bitwarden
+	KeyFile     string `json:"key_file,omitempty"`
 	Notes       string `json:"notes,omitempty"`
 }
 
-// Config represents the application configuration
 type Config struct {
 	Connections []SSHConnection `json:"connections"`
 	LastUsed    string          `json:"last_used,omitempty"`

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -7,9 +7,11 @@ type SSHConnection struct {
 	Host        string `json:"host"`
 	Port        int    `json:"port"`
 	Username    string `json:"username"`
-	Password    string `json:"password,omitempty"`
-	KeyFile     string `json:"key_file,omitempty"`
+	Password    string `json:"password,omitempty"`   // If use_password: password, if keyfile: private key content
+	PublicKey   string `json:"public_key,omitempty"` // Public key content
 	UsePassword bool   `json:"use_password"`
+	KeyFile     string `json:"key_file,omitempty"` // Path or original file, not used for Bitwarden
+	Notes       string `json:"notes,omitempty"`
 }
 
 // Config represents the application configuration

--- a/internal/config/pathutil.go
+++ b/internal/config/pathutil.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"os/user"
+	"strings"
+)
+
+// ExpandPath expands ~ to the user's home directory.
+func ExpandPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		usr, err := user.Current()
+		if err == nil {
+			return strings.Replace(path, "~", usr.HomeDir, 1)
+		}
+	}
+	return path
+}

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -1,0 +1,11 @@
+package config
+
+// Storage defines the backend interface for SSH connection storage.
+type Storage interface {
+	Load() error
+	Save() error
+	AddConnection(conn SSHConnection) error
+	DeleteConnection(id string) error
+	GetConnection(id string) (SSHConnection, bool)
+	ListConnections() []SSHConnection
+}

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -8,4 +8,5 @@ type Storage interface {
 	DeleteConnection(id string) error
 	GetConnection(id string) (SSHConnection, bool)
 	ListConnections() []SSHConnection
+	EditConnection(conn SSHConnection) error
 }

--- a/internal/ssh/session_unix.go
+++ b/internal/ssh/session_unix.go
@@ -1,0 +1,394 @@
+//go:build !windows
+// +build !windows
+
+package ssh
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/term"
+	"ssh-x-term/internal/config"
+)
+
+// Session represents an SSH terminal session
+type Session struct {
+	client      *Client
+	session     *ssh.Session
+	stdin       io.WriteCloser
+	stdout      io.Reader
+	stderr      io.Reader
+	originalFd  int
+	originalTty *term.State
+	done        chan struct{}
+	wg          sync.WaitGroup
+	exiting     bool
+	exitMutex   sync.Mutex
+}
+
+// NewSession creates a new SSH terminal session
+func NewSession(connConfig config.SSHConnection) (*Session, error) {
+	// Create a new SSH client
+	client, err := NewClient(connConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new SSH session
+	sshSession, err := client.NewSession()
+	if err != nil {
+		client.Close()
+		return nil, fmt.Errorf("failed to create SSH session: %w", err)
+	}
+
+	// Set up terminal modes
+	modes := ssh.TerminalModes{
+		ssh.ECHO:          1,     // enable echoing
+		ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
+		ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
+		ssh.ICANON:        1,     // canonical input mode
+		ssh.ISIG:          1,     // signals enabled
+	}
+
+	// Request pseudo terminal
+	fd := int(os.Stdin.Fd())
+	width, height, err := term.GetSize(fd)
+	if err != nil {
+		sshSession.Close()
+		client.Close()
+		return nil, fmt.Errorf("failed to get terminal size: %w", err)
+	}
+
+	if err := sshSession.RequestPty("xterm-256color", height, width, modes); err != nil {
+		sshSession.Close()
+		client.Close()
+		return nil, fmt.Errorf("failed to request PTY: %w", err)
+	}
+
+	// Set up pipes for stdin, stdout, stderr
+	stdin, err := sshSession.StdinPipe()
+	if err != nil {
+		sshSession.Close()
+		client.Close()
+		return nil, fmt.Errorf("failed to set up stdin pipe: %w", err)
+	}
+
+	stdout, err := sshSession.StdoutPipe()
+	if err != nil {
+		sshSession.Close()
+		client.Close()
+		return nil, fmt.Errorf("failed to set up stdout pipe: %w", err)
+	}
+
+	stderr, err := sshSession.StderrPipe()
+	if err != nil {
+		sshSession.Close()
+		client.Close()
+		return nil, fmt.Errorf("failed to set up stderr pipe: %w", err)
+	}
+
+	s := &Session{
+		client:     client,
+		session:    sshSession,
+		stdin:      stdin,
+		stdout:     stdout,
+		stderr:     stderr,
+		originalFd: fd,
+		done:       make(chan struct{}),
+		exiting:    false,
+	}
+
+	return s, nil
+}
+
+// safeWrite attempts to write to stdin, handling potential EOF errors during exit
+func (s *Session) safeWrite(data []byte) (int, error) {
+	s.exitMutex.Lock()
+	exiting := s.exiting
+	s.exitMutex.Unlock()
+
+	if exiting {
+		return len(data), nil // Simulate successful write during exit
+	}
+
+	n, err := s.stdin.Write(data)
+	if err != nil && err == io.EOF {
+		// If we get EOF, mark as exiting to prevent further writes
+		s.exitMutex.Lock()
+		s.exiting = true
+		s.exitMutex.Unlock()
+
+		// Don't report EOF as error during exit process
+		return n, nil
+	}
+	return n, err
+}
+
+// Start starts the SSH session
+func (s *Session) Start() error {
+	// Store original terminal state
+	var err error
+	s.originalTty, err = term.MakeRaw(s.originalFd)
+	if err != nil {
+		return fmt.Errorf("failed to set terminal to raw mode: %w", err)
+	}
+
+	// Handle window resize
+	winch := make(chan os.Signal, 1)
+	signal.Notify(winch, syscall.SIGWINCH)
+	defer signal.Stop(winch)
+
+	go func() {
+		for {
+			select {
+			case <-winch:
+				s.resizeTerminal()
+			case <-s.done:
+				return
+			}
+		}
+	}()
+
+	// Trigger initial resize
+	s.resizeTerminal()
+
+	// Start shell
+	if err := s.session.Shell(); err != nil {
+		term.Restore(s.originalFd, s.originalTty)
+		return fmt.Errorf("failed to start shell: %w", err)
+	}
+
+	// Handle input and output with improved buffering
+	s.wg.Add(3)
+
+	// Handle stdin with improved buffering
+	go func() {
+		defer s.wg.Done()
+
+		buf := make([]byte, 1024)
+		for {
+			select {
+			case <-s.done:
+				return
+			default:
+				n, err := os.Stdin.Read(buf)
+				if err != nil {
+					if err != io.EOF {
+						// Only log if not EOF
+						fmt.Fprintf(os.Stderr, "stdin read error: %v\n", err)
+					}
+					return
+				}
+
+				if n > 0 {
+					// Check if we're in an exiting state before writing
+					s.exitMutex.Lock()
+					exiting := s.exiting
+					s.exitMutex.Unlock()
+
+					if exiting {
+						// If we're exiting, don't try to write any more data
+						continue
+					}
+
+					// Write in chunks to prevent blocking
+					written := 0
+					for written < n {
+						wn, err := s.safeWrite(buf[written:n])
+						if err != nil {
+							// Only log if it's not an EOF during exit
+							s.exitMutex.Lock()
+							exiting := s.exiting
+							s.exitMutex.Unlock()
+
+							if !exiting {
+								fmt.Fprintf(os.Stderr, "stdin write error: %v\n", err)
+							}
+							return
+						}
+						written += wn
+						if written < n {
+							// Check if we need to stop
+							select {
+							case <-s.done:
+								return
+							default:
+								// Continue writing remaining data
+							}
+						}
+					}
+				}
+			}
+		}
+	}()
+
+	// Create a custom stdout writer that preserves cursor visibility
+	stdoutWriter := &cursorPreservingWriter{
+		out:     os.Stdout,
+		session: s,
+	}
+
+	// Handle stdout with cursor preservation
+	go func() {
+		defer s.wg.Done()
+		io.Copy(stdoutWriter, s.stdout)
+	}()
+
+	// Handle stderr
+	go func() {
+		defer s.wg.Done()
+		io.Copy(os.Stderr, s.stderr)
+	}()
+
+	// Wait for session to complete
+	err = s.session.Wait()
+
+	// Mark as exiting to prevent further stdin writes
+	s.exitMutex.Lock()
+	s.exiting = true
+	s.exitMutex.Unlock()
+
+	// Signal all goroutines to stop
+	close(s.done)
+
+	// Wait for all goroutines to finish (with timeout)
+	waitCh := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(waitCh)
+	}()
+
+	// Wait with timeout
+	select {
+	case <-waitCh:
+		// Normal completion
+	case <-time.After(500 * time.Millisecond):
+		// Timeout - force continue
+	}
+
+	// We don't show cursor here because it might cause an EOF error
+	// The cursor visibility will be handled by BubbleTea
+
+	return err
+}
+
+// cursorPreservingWriter is a custom io.Writer that ensures cursor visibility
+type cursorPreservingWriter struct {
+	out     io.Writer
+	session *Session
+}
+
+func (w *cursorPreservingWriter) Write(p []byte) (n int, err error) {
+	// Write the actual data
+	return w.out.Write(p)
+}
+
+// containsSequence checks if a byte slice contains an escape sequence
+func containsSequence(data []byte, sequence string) bool {
+	seqBytes := []byte(sequence)
+	if len(seqBytes) > len(data) {
+		return false
+	}
+
+	// Simple search - could be optimized for production
+	for i := 0; i <= len(data)-len(seqBytes); i++ {
+		match := true
+		for j := 0; j < len(seqBytes); j++ {
+			if data[i+j] != seqBytes[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// Close closes the SSH session and restores the terminal
+func (s *Session) Close() error {
+	// Mark as exiting first to prevent further stdin writes
+	s.exitMutex.Lock()
+	s.exiting = true
+	s.exitMutex.Unlock()
+
+	// Signal all goroutines to stop
+	select {
+	case <-s.done:
+		// Already closed
+	default:
+		close(s.done)
+	}
+
+	// Wait for all goroutines to finish (with timeout)
+	waitCh := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(waitCh)
+	}()
+
+	// Wait with timeout
+	select {
+	case <-waitCh:
+		// Normal completion
+	case <-time.After(500 * time.Millisecond):
+		// Timeout - force continue
+	}
+
+	// We intentionally don't try to show cursor here because it might cause EOF errors
+	// Let BubbleTea handle cursor visibility after we return
+
+	// Restore terminal state
+	if s.originalTty != nil {
+		term.Restore(s.originalFd, s.originalTty)
+	}
+
+	// Close session and client
+	var sessionErr, clientErr error
+	if s.session != nil {
+		sessionErr = s.session.Close()
+	}
+	if s.client != nil {
+		clientErr = s.client.Close()
+	}
+
+	if sessionErr != nil {
+		return sessionErr
+	}
+	return clientErr
+}
+
+// resizeTerminal updates the terminal size in the SSH session
+func (s *Session) resizeTerminal() {
+	// Don't attempt to resize if we're exiting
+	s.exitMutex.Lock()
+	exiting := s.exiting
+	s.exitMutex.Unlock()
+
+	if exiting {
+		return
+	}
+
+	width, height, err := term.GetSize(s.originalFd)
+	if err != nil {
+		return
+	}
+	s.session.WindowChange(height, width)
+}
+
+// IsTerminated checks if the session has been terminated
+func (s *Session) IsTerminated() bool {
+	select {
+	case <-s.done:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/ssh/session_unix.go
+++ b/internal/ssh/session_unix.go
@@ -342,9 +342,6 @@ func (s *Session) Close() error {
 		// Timeout - force continue
 	}
 
-	// We intentionally don't try to show cursor here because it might cause EOF errors
-	// Let BubbleTea handle cursor visibility after we return
-
 	// Restore terminal state
 	if s.originalTty != nil {
 		term.Restore(s.originalFd, s.originalTty)

--- a/internal/ssh/session_windows.go
+++ b/internal/ssh/session_windows.go
@@ -125,9 +125,6 @@ func (s *Session) Start() error {
 		return fmt.Errorf("failed to set terminal to raw mode: %w", err)
 	}
 
-	// CRITICAL: We do NOT use defer for terminal restoration here
-	// Instead, we explicitly restore when necessary
-
 	// Start shell
 	if err := s.session.Shell(); err != nil {
 		term.Restore(s.originalFd, s.originalTty)

--- a/internal/ui/components/bitwarden_config.go
+++ b/internal/ui/components/bitwarden_config.go
@@ -145,9 +145,6 @@ func (f *BitwardenConfigForm) Config() (serverURL, email string) {
 }
 
 func (f *BitwardenConfigForm) validateForm() (bool, string) {
-	if strings.TrimSpace(f.inputs[0].Value()) == "" {
-		return false, "Server URL is required."
-	}
 	if strings.TrimSpace(f.inputs[1].Value()) == "" {
 		return false, "Email is required."
 	}

--- a/internal/ui/components/bitwarden_config.go
+++ b/internal/ui/components/bitwarden_config.go
@@ -1,0 +1,155 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	bwFocusedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+	bwBlurredStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	bwNoStyle       = lipgloss.NewStyle()
+	bwFocusedButton = bwFocusedStyle.Render("[ Submit ]")
+	bwBlurredButton = fmt.Sprintf("[ %s ]", bwBlurredStyle.Render("Submit"))
+)
+
+type BitwardenConfigForm struct {
+	inputs     []textinput.Model
+	focusIndex int
+	submitted  bool
+	canceled   bool
+	ErrorMsg   string
+}
+
+// NewBitwardenConfigForm creates a new Bitwarden config form
+func NewBitwardenConfigForm() *BitwardenConfigForm {
+	inputs := make([]textinput.Model, 2)
+
+	// Server URL
+	inputs[0] = textinput.New()
+	inputs[0].Placeholder = "Bitwarden Server URL"
+	inputs[0].Focus()
+	inputs[0].Width = 32
+	inputs[0].Prompt = "> "
+	inputs[0].PromptStyle = bwFocusedStyle
+	inputs[0].TextStyle = bwFocusedStyle
+
+	// Email
+	inputs[1] = textinput.New()
+	inputs[1].Placeholder = "Email"
+	inputs[1].Width = 32
+	inputs[1].Prompt = "> "
+	inputs[1].PromptStyle = bwBlurredStyle
+	inputs[1].TextStyle = bwBlurredStyle
+
+	return &BitwardenConfigForm{
+		inputs:     inputs,
+		focusIndex: 0,
+	}
+}
+
+func (f *BitwardenConfigForm) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (f *BitwardenConfigForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			f.canceled = true
+			return f, nil
+		case "tab", "down":
+			f.focusIndex++
+			if f.focusIndex > len(f.inputs) { // past Submit button
+				f.focusIndex = 0
+			}
+		case "shift+tab", "up":
+			f.focusIndex--
+			if f.focusIndex < 0 {
+				f.focusIndex = len(f.inputs)
+			}
+		case "enter":
+			if f.focusIndex == len(f.inputs) {
+				// Submit button
+				if valid, err := f.validateForm(); valid {
+					f.submitted = true
+					return f, nil
+				} else {
+					f.ErrorMsg = err
+				}
+			}
+		}
+	}
+
+	// Set focus/blurring on inputs
+	for i := 0; i < len(f.inputs); i++ {
+		if i == f.focusIndex {
+			f.inputs[i].Focus()
+			f.inputs[i].PromptStyle = bwFocusedStyle
+			f.inputs[i].TextStyle = bwFocusedStyle
+		} else {
+			f.inputs[i].Blur()
+			f.inputs[i].PromptStyle = bwBlurredStyle
+			f.inputs[i].TextStyle = bwBlurredStyle
+		}
+	}
+
+	if f.focusIndex < len(f.inputs) {
+		newInput, cmd := f.inputs[f.focusIndex].Update(msg)
+		f.inputs[f.focusIndex] = newInput
+		cmds = append(cmds, cmd)
+	}
+
+	return f, tea.Batch(cmds...)
+}
+
+func (f *BitwardenConfigForm) View() string {
+	var b strings.Builder
+	b.WriteString("Bitwarden Storage Setup\n\n")
+	b.WriteString(fmt.Sprintf("%s\n%s\n\n", "Server URL:", f.inputs[0].View()))
+	b.WriteString(fmt.Sprintf("%s\n%s\n\n", "Email:", f.inputs[1].View()))
+
+	// Render submit button
+	button := bwBlurredButton
+	if f.focusIndex == len(f.inputs) {
+		button = bwFocusedButton
+	}
+	fmt.Fprintf(&b, "\n%s\n\n", button)
+
+	// Show error message if any
+	if f.ErrorMsg != "" {
+		fmt.Fprintf(&b, "\n%s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render(f.ErrorMsg))
+	}
+
+	b.WriteString(bwBlurredStyle.Render("\nTab/Shift+Tab/Up/Down to move, Enter to submit, Esc/Ctrl+C to cancel\n"))
+	return b.String()
+}
+
+func (f *BitwardenConfigForm) IsSubmitted() bool {
+	return f.submitted
+}
+
+func (f *BitwardenConfigForm) IsCanceled() bool {
+	return f.canceled
+}
+
+func (f *BitwardenConfigForm) Config() (serverURL, email string) {
+	return f.inputs[0].Value(), f.inputs[1].Value()
+}
+
+func (f *BitwardenConfigForm) validateForm() (bool, string) {
+	if strings.TrimSpace(f.inputs[0].Value()) == "" {
+		return false, "Server URL is required."
+	}
+	if strings.TrimSpace(f.inputs[1].Value()) == "" {
+		return false, "Email is required."
+	}
+	return true, ""
+}

--- a/internal/ui/components/bitwarden_config.go
+++ b/internal/ui/components/bitwarden_config.go
@@ -67,7 +67,7 @@ func (f *BitwardenConfigForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return f, nil
 		case "tab", "down":
 			f.focusIndex++
-			if f.focusIndex > len(f.inputs) { // past Submit button
+			if f.focusIndex > len(f.inputs) {
 				f.focusIndex = 0
 			}
 		case "shift+tab", "up":
@@ -77,7 +77,6 @@ func (f *BitwardenConfigForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "enter":
 			if f.focusIndex == len(f.inputs) {
-				// Submit button
 				if valid, err := f.validateForm(); valid {
 					f.submitted = true
 					return f, nil

--- a/internal/ui/components/bitwarden_login_form.go
+++ b/internal/ui/components/bitwarden_login_form.go
@@ -1,0 +1,102 @@
+package components
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type BitwardenLoginForm struct {
+	passwordInput textinput.Model
+	otpInput      textinput.Model
+	stage         int // 0 = password, 1 = otp, 2 = done
+	submitted     bool
+	canceled      bool
+	errorMsg      string
+}
+
+func NewBitwardenLoginForm() *BitwardenLoginForm {
+	ti := textinput.New()
+	ti.Placeholder = "Password"
+	ti.EchoMode = textinput.EchoPassword
+	ti.Focus()
+	return &BitwardenLoginForm{
+		passwordInput: ti,
+		stage:         0,
+	}
+}
+
+func (f *BitwardenLoginForm) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (f *BitwardenLoginForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if f.submitted || f.canceled {
+		return f, nil
+	}
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			f.canceled = true
+			return f, nil
+		case "enter":
+			if f.stage == 0 {
+				if f.passwordInput.Value() == "" {
+					f.errorMsg = "Password required"
+					return f, nil
+				}
+				f.stage = 1
+				f.otpInput = textinput.New()
+				f.otpInput.Placeholder = "2FA Code (if enabled, else leave blank)"
+				f.otpInput.CharLimit = 8
+				f.otpInput.Focus()
+				return f, nil
+			} else if f.stage == 1 {
+				f.submitted = true
+				return f, nil
+			}
+		}
+	}
+	if f.stage == 0 {
+		var cmd tea.Cmd
+		f.passwordInput, cmd = f.passwordInput.Update(msg)
+		return f, cmd
+	} else if f.stage == 1 {
+		var cmd tea.Cmd
+		f.otpInput, cmd = f.otpInput.Update(msg)
+		return f, cmd
+	}
+	return f, nil
+}
+
+func (f *BitwardenLoginForm) View() string {
+	if f.canceled {
+		return "Login canceled."
+	}
+	if f.stage == 0 {
+		return "Enter your Bitwarden password:\n" + f.passwordInput.View() + "\n" + f.errorMsg
+	} else if f.stage == 1 {
+		return "Enter 2FA code if required (or leave blank):\n" + f.otpInput.View() + "\n" + f.errorMsg
+	}
+	return "Logging in..."
+}
+
+func (f *BitwardenLoginForm) IsSubmitted() bool {
+	return f.submitted
+}
+
+func (f *BitwardenLoginForm) IsCanceled() bool {
+	return f.canceled
+}
+
+func (f *BitwardenLoginForm) Password() string {
+	return f.passwordInput.Value()
+}
+
+func (f *BitwardenLoginForm) OTP() string {
+	return f.otpInput.Value()
+}
+
+func (f *BitwardenLoginForm) SetError(msg string) {
+	f.errorMsg = msg
+}

--- a/internal/ui/components/bitwarden_login_form.go
+++ b/internal/ui/components/bitwarden_login_form.go
@@ -19,6 +19,7 @@ func NewBitwardenLoginForm() *BitwardenLoginForm {
 	ti.Placeholder = "Password"
 	ti.EchoMode = textinput.EchoPassword
 	ti.Focus()
+	ti.Width = 40
 	return &BitwardenLoginForm{
 		passwordInput: ti,
 		stage:         0,
@@ -50,6 +51,7 @@ func (f *BitwardenLoginForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				f.otpInput.Placeholder = "2FA Code (if enabled, else leave blank)"
 				f.otpInput.CharLimit = 8
 				f.otpInput.Focus()
+				f.otpInput.Width = 40
 				return f, nil
 			} else if f.stage == 1 {
 				f.submitted = true

--- a/internal/ui/components/bitwarden_unlock_form.go
+++ b/internal/ui/components/bitwarden_unlock_form.go
@@ -1,0 +1,71 @@
+package components
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type BitwardenUnlockForm struct {
+	passwordInput textinput.Model
+	submitted     bool
+	canceled      bool
+	errorMsg      string
+}
+
+func NewBitwardenUnlockForm() *BitwardenUnlockForm {
+	ti := textinput.New()
+	ti.Placeholder = "Vault Password"
+	ti.EchoMode = textinput.EchoPassword
+	ti.Focus()
+	return &BitwardenUnlockForm{
+		passwordInput: ti,
+	}
+}
+
+func (f *BitwardenUnlockForm) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (f *BitwardenUnlockForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if f.submitted || f.canceled {
+		return f, nil
+	}
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			f.canceled = true
+			return f, nil
+		case "enter":
+			if f.passwordInput.Value() == "" {
+				f.errorMsg = "Password required"
+				return f, nil
+			}
+			f.submitted = true
+			return f, nil
+		}
+	}
+	var cmd tea.Cmd
+	f.passwordInput, cmd = f.passwordInput.Update(msg)
+	return f, cmd
+}
+
+func (f *BitwardenUnlockForm) View() string {
+	if f.canceled {
+		return "Unlock canceled."
+	}
+	return "Enter your Bitwarden vault password to unlock:\n" + f.passwordInput.View() + "\n" + f.errorMsg
+}
+
+func (f *BitwardenUnlockForm) IsSubmitted() bool {
+	return f.submitted
+}
+func (f *BitwardenUnlockForm) IsCanceled() bool {
+	return f.canceled
+}
+func (f *BitwardenUnlockForm) Password() string {
+	return f.passwordInput.Value()
+}
+func (f *BitwardenUnlockForm) SetError(msg string) {
+	f.errorMsg = msg
+}

--- a/internal/ui/components/bitwarden_unlock_form.go
+++ b/internal/ui/components/bitwarden_unlock_form.go
@@ -17,6 +17,7 @@ func NewBitwardenUnlockForm() *BitwardenUnlockForm {
 	ti.Placeholder = "Vault Password"
 	ti.EchoMode = textinput.EchoPassword
 	ti.Focus()
+	ti.Width = 40
 	return &BitwardenUnlockForm{
 		passwordInput: ti,
 	}

--- a/internal/ui/components/form.go
+++ b/internal/ui/components/form.go
@@ -92,7 +92,7 @@ func NewConnectionForm(conn *config.SSHConnection) *ConnectionForm {
 
 	// Key file input
 	inputs[5] = textinput.New()
-	inputs[5].Placeholder = "Path to SSH key (default: ~/.ssh/id_rsa)"
+	inputs[5].Placeholder = "Path to SSH key (example: ~/.ssh/id_rsa)"
 	inputs[5].Width = 60
 	inputs[5].Prompt = "> "
 

--- a/internal/ui/components/form.go
+++ b/internal/ui/components/form.go
@@ -73,7 +73,7 @@ func NewConnectionForm(conn *config.SSHConnection) *ConnectionForm {
 	// Port input
 	inputs[2] = textinput.New()
 	inputs[2].Placeholder = "Port (default: 22)"
-	inputs[2].Width = 10
+	inputs[2].Width = 40
 	inputs[2].Prompt = "> "
 
 	// Username input
@@ -194,7 +194,11 @@ func (m *ConnectionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+p":
 			// Toggle between password and key authentication
 			m.usePassword = !m.usePassword
-
+			if m.usePassword {
+				m.inputs[4].SetValue("")
+			} else {
+				m.inputs[5].SetValue("")
+			}
 		}
 	}
 
@@ -309,6 +313,9 @@ func (m *ConnectionForm) updateConnection() {
 			strconv.FormatInt(time.Now().UnixNano(), 10)
 		m.inputs[6].SetValue(id)
 	}
+
+	// Debug print
+	fmt.Printf("DEBUG: Submitting connection with ID: %s (editing: %v)\n", id, m.editing)
 
 	// Parse port
 	port := 22

--- a/internal/ui/components/storage_select.go
+++ b/internal/ui/components/storage_select.go
@@ -1,0 +1,80 @@
+package components
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type StorageBackend int
+
+const (
+	StorageLocal StorageBackend = iota
+	StorageBitwarden
+)
+
+type StorageSelect struct {
+	options       []string
+	selectedIndex int
+	chosen        bool
+	canceled      bool
+}
+
+func NewStorageSelect() *StorageSelect {
+	return &StorageSelect{
+		options: []string{"Local (file)", "Bitwarden"},
+	}
+}
+
+func (s *StorageSelect) Init() tea.Cmd {
+	return nil
+}
+
+func (s *StorageSelect) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "up", "k":
+			if s.selectedIndex > 0 {
+				s.selectedIndex--
+			}
+		case "down", "j":
+			if s.selectedIndex < len(s.options)-1 {
+				s.selectedIndex++
+			}
+		case "enter":
+			s.chosen = true
+			return s, nil
+		case "esc":
+			s.canceled = true
+			return s, nil
+		}
+	}
+	return s, nil
+}
+
+func (s *StorageSelect) View() string {
+	out := "Choose storage backend:\n\n"
+	for i, opt := range s.options {
+		style := lipgloss.NewStyle()
+		prefix := "  "
+		if i == s.selectedIndex {
+			style = style.Bold(true).Foreground(lipgloss.Color("205"))
+			prefix = "> "
+		}
+		out += style.Render(prefix+opt) + "\n"
+	}
+	out += "\n(Use ↑/↓ and Enter)"
+	return out
+}
+
+func (s *StorageSelect) SelectedBackend() StorageBackend {
+	return StorageBackend(s.selectedIndex)
+}
+
+func (s *StorageSelect) IsChosen() bool {
+	return s.chosen
+}
+
+func (s *StorageSelect) IsCanceled() bool {
+	return s.canceled
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -79,6 +80,12 @@ func (m *Model) LoadConnections() {
 	}
 }
 
+// sanitizeFileName replaces all non-alphanumeric characters with underscores
+func sanitizeFileName(name string) string {
+	re := regexp.MustCompile(`[^a-zA-Z0-9]`)
+	return re.ReplaceAllString(name, "_")
+}
+
 func getTempKeyFile(conn config.SSHConnection) (string, error) {
 	usr, err := user.Current()
 	if err != nil {
@@ -88,7 +95,8 @@ func getTempKeyFile(conn config.SSHConnection) (string, error) {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", err
 	}
-	keyPath := filepath.Join(dir, fmt.Sprintf("id_%s", conn.Name))
+	safeName := sanitizeFileName(conn.Name)
+	keyPath := filepath.Join(dir, fmt.Sprintf("id_%s", safeName))
 	if err := os.WriteFile(keyPath, []byte(conn.Password), 0600); err != nil {
 		return "", err
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -70,7 +70,11 @@ func (m *Model) LoadConnections() {
 		if height <= 0 {
 			height = 20
 		}
-		m.connectionList = components.NewConnectionList(m.storageBackend.ListConnections(), width, height)
+		visibleListHeight := height - headerLines - footerLines
+		if visibleListHeight < 5 {
+			visibleListHeight = 5
+		}
+		m.connectionList = components.NewConnectionList(m.storageBackend.ListConnections(), width, visibleListHeight)
 	}
 }
 
@@ -165,7 +169,11 @@ func (m *Model) handleComponentResult(model tea.Model, cmd tea.Cmd) tea.Cmd {
 					if height <= 0 {
 						height = 20
 					}
-					m.connectionList = components.NewConnectionList(nil, width, height)
+					visibleListHeight := height - headerLines - footerLines
+					if visibleListHeight < 5 {
+						visibleListHeight = 5
+					}
+					m.connectionList = components.NewConnectionList(m.storageBackend.ListConnections(), width, visibleListHeight)
 					m.state = StateConnectionList
 				}
 				return nil
@@ -260,10 +268,14 @@ func (m *Model) handleComponentResult(model tea.Model, cmd tea.Cmd) tea.Cmd {
 			if height <= 0 {
 				height = 20
 			}
+			visibleListHeight := height - headerLines - footerLines
+			if visibleListHeight < 5 {
+				visibleListHeight = 5
+			}
 			if err := m.bitwardenManager.Load(); err != nil {
 				m.errorMessage = fmt.Sprintf("Failed to load Bitwarden connections: %v", err)
 			}
-			m.connectionList = components.NewConnectionList(m.bitwardenManager.ListConnections(), width, height)
+			m.connectionList = components.NewConnectionList(m.storageBackend.ListConnections(), width, visibleListHeight)
 			m.state = StateConnectionList
 			m.bitwardenUnlockForm = nil
 			return nil
@@ -358,11 +370,9 @@ func (m *Model) handleComponentResult(model tea.Model, cmd tea.Cmd) tea.Cmd {
 			} else {
 				m.connectionForm = nil
 				m.state = StateConnectionList
-				// Refresh connections
 				if err := m.storageBackend.Load(); err != nil {
 					m.errorMessage = fmt.Sprintf("Failed to reload connections: %s", err)
 				}
-				// Rebuild the list to show new connection
 				width, height := m.width, m.height
 				if width <= 0 {
 					width = 60
@@ -370,10 +380,13 @@ func (m *Model) handleComponentResult(model tea.Model, cmd tea.Cmd) tea.Cmd {
 				if height <= 0 {
 					height = 20
 				}
-				m.connectionList = components.NewConnectionList(m.storageBackend.ListConnections(), width, height)
+				visibleListHeight := height - headerLines - footerLines
+				if visibleListHeight < 5 {
+					visibleListHeight = 5
+				}
+				m.connectionList = components.NewConnectionList(m.storageBackend.ListConnections(), width, visibleListHeight)
 			}
-			m.connectionForm = nil
-			return nil
+			return nil // or try: return tea.ClearScreen
 		}
 
 	case StateSSHTerminal:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -14,53 +15,60 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// AppState represents the current state of the application
 type AppState int
 
 const (
-	StateConnectionList AppState = iota
+	StateSelectStorage AppState = iota
+	StateBitwardenConfig
+	StateConnectionList
 	StateAddConnection
 	StateEditConnection
 	StateSSHTerminal
+	headerLines = 4
+	footerLines = 4
 )
 
-// Model represents the UI model for the application
 type Model struct {
-	configManager  *config.ConfigManager
 	state          AppState
+	storageSelect  *components.StorageSelect
+	storageBackend config.Storage
+	configManager  *config.ConfigManager
 	width          int
 	height         int
 	connectionList *components.ConnectionList
 	connectionForm *components.ConnectionForm
 	terminal       *components.TerminalComponent
+	bitwardenForm  *components.BitwardenConfigForm
 	errorMessage   string
 }
 
-// NewModel creates a new UI model
-func NewModel(configManager *config.ConfigManager) *Model {
-	connectionList := components.NewConnectionList(configManager.Config.Connections)
-
+func NewModel() *Model {
 	return &Model{
-		configManager:  configManager,
-		state:          StateConnectionList,
-		connectionList: connectionList,
+		state:         StateSelectStorage,
+		storageSelect: components.NewStorageSelect(),
 	}
 }
 
-// Init initializes the model
 func (m *Model) Init() tea.Cmd {
 	return nil
 }
 
-// LoadConnections loads connections from config and updates the connection list
 func (m *Model) LoadConnections() {
-	m.connectionList.SetConnections(m.configManager.Config.Connections)
+	if m.storageBackend != nil && m.connectionList != nil {
+		m.connectionList.SetConnections(m.storageBackend.ListConnections())
+	}
 }
 
-// getActiveComponent returns the currently active component
 func (m *Model) getActiveComponent() tea.Model {
 	switch m.state {
+	case StateSelectStorage:
+		return m.storageSelect
+	case StateBitwardenConfig:
+		return m.bitwardenForm
 	case StateConnectionList:
+		if m.connectionList == nil {
+			return nil
+		}
 		return m.connectionList
 	case StateAddConnection, StateEditConnection:
 		return m.connectionForm
@@ -71,80 +79,171 @@ func (m *Model) getActiveComponent() tea.Model {
 	}
 }
 
-// handleComponentResult handles the result of a component's update function
 func (m *Model) handleComponentResult(model tea.Model, cmd tea.Cmd) tea.Cmd {
 	switch m.state {
+	case StateSelectStorage:
+		m.storageSelect = model.(*components.StorageSelect)
+		if m.storageSelect.IsCanceled() {
+			return tea.Quit
+		}
+		if m.storageSelect.IsChosen() {
+			switch m.storageSelect.SelectedBackend() {
+			case components.StorageLocal:
+				cm, err := config.NewConfigManager()
+				if err != nil {
+					m.errorMessage = fmt.Sprintf("Error initializing local config: %s", err)
+					return nil
+				}
+				if err := cm.Load(); err != nil {
+					m.errorMessage = fmt.Sprintf("Error loading config: %s", err)
+					return nil
+				}
+				m.storageBackend = cm
+				m.configManager = cm
+				width, height := m.width, m.height
+				if width <= 0 {
+					width = 60
+				}
+				if height <= 0 {
+					height = 20
+				}
+				visibleListHeight := height - headerLines - footerLines
+				if visibleListHeight < 5 {
+					visibleListHeight = 5
+				}
+				m.connectionList = components.NewConnectionList(cm.ListConnections(), width, visibleListHeight)
+				m.state = StateConnectionList
+				// Reset the storage select so it's clean if user comes back
+				m.storageSelect = components.NewStorageSelect()
+			case components.StorageBitwarden:
+				m.bitwardenForm = components.NewBitwardenConfigForm()
+				m.state = StateBitwardenConfig
+			}
+		}
+		return nil
+
+	case StateBitwardenConfig:
+		m.bitwardenForm = model.(*components.BitwardenConfigForm)
+		if m.bitwardenForm.IsCanceled() {
+			m.bitwardenForm = nil
+			m.state = StateSelectStorage
+			m.storageSelect = components.NewStorageSelect() // <-- RESET!
+			return nil
+		}
+		if m.bitwardenForm.IsSubmitted() {
+			serverURL, email := m.bitwardenForm.Config()
+			cfg := &config.BitwardenConfig{ServerURL: serverURL, Email: email}
+			bwm, err := config.NewBitwardenManager(cfg)
+			if err != nil {
+				m.bitwardenForm.ErrorMsg = err.Error()
+				return nil
+			}
+			m.storageBackend = bwm
+			width, height := m.width, m.height
+			if width <= 0 {
+				width = 60
+			}
+			if height <= 0 {
+				height = 20
+			}
+			m.connectionList = components.NewConnectionList(bwm.ListConnections(), width, height)
+			m.state = StateConnectionList
+			// Reset Bitwarden form after submit
+			m.bitwardenForm = nil
+			return nil
+		}
+		return nil
+
 	case StateConnectionList:
 		m.connectionList = model.(*components.ConnectionList)
 		if conn := m.connectionList.SelectedConnection(); conn != nil {
-			if !m.connectionList.OpenInNewTerminal() {
-				/*
-					SSH session in the same terminal
-					A connection was selected, start SSH terminal
-				*/
-				m.terminal = components.NewTerminalComponent(*conn)
-				m.state = StateSSHTerminal
-				m.connectionList.Reset()
-				return m.terminal.Init()
+			openInNewWindow := m.connectionList.OpenInNewTerminal()
+
+			isWindows := runtime.GOOS == "windows"
+
+			if !isWindows {
+				// Unix-like
+				if openInNewWindow {
+					sshArgs := []string{}
+					if conn.KeyFile != "" {
+						sshArgs = append(sshArgs, "-i", filepath.Clean(conn.KeyFile))
+					}
+					if conn.Port != 22 && conn.Port != 0 {
+						sshArgs = append(sshArgs, "-p", strconv.Itoa(conn.Port))
+					}
+					userHost := fmt.Sprintf("%s@%s", conn.Username, conn.Host)
+					sshArgs = append(sshArgs, userHost)
+
+					sshCommand := fmt.Sprintf("ssh %s", strings.Join(sshArgs, " "))
+					windowName := fmt.Sprintf("%s@%s:%d - %s", conn.Username, conn.Host, conn.Port, conn.Name)
+					cmd := exec.Command("tmux", "new-window", "-n", windowName, sshCommand)
+					err := cmd.Start()
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "Error launching tmux window: %v\n", err)
+					}
+					if conn.UsePassword && conn.Password != "" {
+						tea.Println("Password authentication not supported in this mode. Use manual entry or key-based login.")
+					}
+					m.state = StateConnectionList
+					m.connectionList.Reset()
+					return nil
+				} else {
+					m.terminal = components.NewTerminalComponent(*conn)
+					m.state = StateSSHTerminal
+					m.connectionList.Reset()
+					return m.terminal.Init()
+				}
 			} else {
-				/*
-				   SSH session in another tmux window
-				   Build SSH command
-				*/
-				sshArgs := []string{}
-				if conn.KeyFile != "" {
-					sshArgs = append(sshArgs, "-i", filepath.Clean(conn.KeyFile))
+				// Windows
+				if openInNewWindow {
+					sshArgs := []string{}
+					if conn.KeyFile != "" {
+						sshArgs = append(sshArgs, "-i", filepath.Clean(conn.KeyFile))
+					}
+					if conn.Port != 22 && conn.Port != 0 {
+						sshArgs = append(sshArgs, "-p", strconv.Itoa(conn.Port))
+					}
+					userHost := fmt.Sprintf("%s@%s", conn.Username, conn.Host)
+					sshArgs = append(sshArgs, userHost)
+
+					cmd := exec.Command("cmd", "/C", "start", "", "ssh")
+					cmd.Args = append(cmd.Args, sshArgs...)
+
+					err := cmd.Start()
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "Error launching terminal: %v\n", err)
+					}
+					if conn.UsePassword && conn.Password != "" {
+						tea.Println("Password authentication not supported in this mode. Use manual entry or key-based login.")
+					}
+					m.state = StateConnectionList
+					m.connectionList.Reset()
+					return nil
+				} else {
+					m.terminal = components.NewTerminalComponent(*conn)
+					m.state = StateSSHTerminal
+					m.connectionList.Reset()
+					return m.terminal.Init()
 				}
-				if conn.Port != 22 && conn.Port != 0 {
-					sshArgs = append(sshArgs, "-p", strconv.Itoa(conn.Port))
-				}
-				userHost := fmt.Sprintf("%s@%s", conn.Username, conn.Host)
-				sshArgs = append(sshArgs, userHost)
-
-				// Build full SSH command
-				sshCommand := fmt.Sprintf("ssh %s", strings.Join(sshArgs, " "))
-
-				// Sanitize and build tmux window name: "user@host:port - ConnectionName"
-				windowName := fmt.Sprintf("%s@%s:%d - %s", conn.Username, conn.Host, conn.Port, conn.Name)
-
-				// Launch tmux new window with name and SSH command
-				cmd := exec.Command("tmux", "new-window", "-n", windowName, sshCommand)
-				err := cmd.Start()
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Error launching tmux window: %v\n", err)
-				}
-
-				// Optional: Warn if password use is enabled
-				if conn.UsePassword && conn.Password != "" {
-					tea.Println("Password authentication not supported in this mode. Use manual entry or key-based login.")
-				}
-
-				// Remain on the connection list view
-				m.state = StateConnectionList
-				m.connectionList.Reset()
-				return nil
 			}
 		}
-
 	case StateAddConnection, StateEditConnection:
 		m.connectionForm = model.(*components.ConnectionForm)
 		if m.connectionForm.IsCanceled() {
-			// Form was canceled, return to connection list
+			m.connectionForm = nil // reset the connection form
 			m.state = StateConnectionList
 			m.connectionList.Reset()
 			return nil
 		}
 		if m.connectionForm.IsSubmitted() {
-			// Form was submitted, save connection
 			conn := m.connectionForm.Connection()
-			err := m.configManager.AddConnection(conn)
-			if err != nil {
+			if err := m.storageBackend.AddConnection(conn); err != nil {
 				m.errorMessage = fmt.Sprintf("Failed to save connection: %s", err)
 			} else {
-				// Reload connections and return to list
 				m.LoadConnections()
 				m.state = StateConnectionList
 			}
+			m.connectionForm = nil // reset the connection form after submit
 			m.connectionList.Reset()
 			return nil
 		}
@@ -152,12 +251,11 @@ func (m *Model) handleComponentResult(model tea.Model, cmd tea.Cmd) tea.Cmd {
 	case StateSSHTerminal:
 		m.terminal = model.(*components.TerminalComponent)
 		if m.terminal.IsFinished() {
-			// Terminal session ended, return to connection list
+			m.terminal = nil // reset the terminal component
 			m.state = StateConnectionList
 			m.connectionList.Reset()
 			return nil
 		}
 	}
-
 	return cmd
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -57,8 +57,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			case msg.String() == "d":
 				selectedItem := m.connectionList.HighlightedConnection()
-				if selectedItem != nil && m.configManager != nil {
-					err := m.configManager.DeleteConnection(selectedItem.ID)
+				if selectedItem != nil && m.storageBackend != nil {
+					err := m.storageBackend.DeleteConnection(selectedItem.ID)
 					if err != nil {
 						m.errorMessage = err.Error()
 					} else {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -16,64 +16,62 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-
-		// Pass window size to active component
+		if m.connectionList != nil {
+			m.connectionList.SetWidth(m.width)
+			m.connectionList.SetHeight(m.height - 4)
+		}
 		if activeComponent := m.getActiveComponent(); activeComponent != nil {
 			model, cmd := activeComponent.Update(msg)
 			return m, m.handleComponentResult(model, cmd)
 		}
 
 	case tea.KeyMsg:
-		listModel := m.connectionList.List()
+		if m.state == StateConnectionList && m.connectionList != nil {
+			listModel := m.connectionList.List()
+			if listModel != nil && listModel.FilterState() == list.Filtering {
+				newList, cmd := listModel.Update(msg)
+				*listModel = newList
+				return m, cmd
+			}
 
-		if listModel.FilterState() == list.Filtering {
-			newList, cmd := listModel.Update(msg)
-			*listModel = newList // update the pointer target
-			return m, cmd
-		}
+			switch {
+			case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
+				m.state = StateSelectStorage
+				return m, m.storageSelect.Init()
 
-		switch {
-		case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+c"))):
-			return m, tea.Quit
+			case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+c"))):
+				return m, tea.Quit
 
-		case m.state == StateConnectionList && msg.String() == "a":
-			// Add new connection
-			m.connectionForm = components.NewConnectionForm(nil)
-			m.state = StateAddConnection
-			return m, m.connectionForm.Init()
-
-		case m.state == StateConnectionList && msg.String() == "e":
-			// Edit selected connection
-			selectedItem := m.connectionList.HighlightedConnection()
-			if selectedItem != nil {
-				m.connectionForm = components.NewConnectionForm(selectedItem)
-				m.state = StateEditConnection
+			case msg.String() == "a":
+				m.connectionForm = components.NewConnectionForm(nil)
+				m.state = StateAddConnection
 				return m, m.connectionForm.Init()
-			}
 
-		case m.state == StateConnectionList && msg.String() == "d":
-			// Delete selected connection
-			selectedItem := m.connectionList.HighlightedConnection()
-			if selectedItem != nil {
-				err := m.configManager.DeleteConnection(selectedItem.ID)
-				if err != nil {
-					m.errorMessage = err.Error()
-				} else {
-					m.LoadConnections()
-					m.connectionList.Reset()
+			case msg.String() == "e":
+				selectedItem := m.connectionList.HighlightedConnection()
+				if selectedItem != nil {
+					m.connectionForm = components.NewConnectionForm(selectedItem)
+					m.state = StateEditConnection
+					return m, m.connectionForm.Init()
 				}
-				return m, nil
+
+			case msg.String() == "d":
+				selectedItem := m.connectionList.HighlightedConnection()
+				if selectedItem != nil && m.configManager != nil {
+					err := m.configManager.DeleteConnection(selectedItem.ID)
+					if err != nil {
+						m.errorMessage = err.Error()
+					} else {
+						m.LoadConnections()
+						m.connectionList.Reset()
+					}
+					return m, nil
+				}
 			}
-			//
-			// case m.state == StateConnectionList && msg.String() == "o":
-			// 	// Mark next selected connection as open in a new terminal
-			// 	m.connectionList.ToggleOpenInNewTerminal()
-			// 	c.openCheckbox.Checked = c.openInNewTerminal
-			// 	return m, nil
 		}
 	}
 
-	// Pass message to active component
+	// Default: pass message to active component
 	if activeComponent := m.getActiveComponent(); activeComponent != nil {
 		model, cmd := activeComponent.Update(msg)
 		return m, m.handleComponentResult(model, cmd)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -25,26 +25,27 @@ var (
 func (m *Model) View() string {
 	var content strings.Builder
 
-	// Render header
 	content.WriteString(titleStyle.Render("SSH-X-Term"))
 	content.WriteString("\n")
 
-	// Render active component
 	if activeComponent := m.getActiveComponent(); activeComponent != nil {
+		defer func() {
+			if r := recover(); r != nil {
+				content.WriteString("\n")
+				content.WriteString(errorStyle.Render("Component error: invalid UI state"))
+			}
+		}()
 		content.WriteString(activeComponent.View())
 	} else {
 		content.WriteString("No active component")
 	}
 
-	// Render error message if any
 	if m.errorMessage != "" {
 		content.WriteString("\n")
 		content.WriteString(errorStyle.Render(m.errorMessage))
-		// Clear error after displaying it
 		m.errorMessage = ""
 	}
 
-	// Render footer with help text based on current state
 	content.WriteString("\n")
 	switch m.state {
 	case StateConnectionList:

--- a/pkg/sshutil/terminal_unix.go
+++ b/pkg/sshutil/terminal_unix.go
@@ -1,3 +1,6 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd
+// +build linux darwin freebsd netbsd openbsd
+
 package sshutil
 
 import (
@@ -87,7 +90,6 @@ func (ts *TerminalSession) handleResize() error {
 	if err != nil {
 		return fmt.Errorf("failed to get terminal size: %w", err)
 	}
-
 	// Optional: handle resize logic (e.g., notify remote, etc.)
 	fmt.Fprintf(os.Stderr, "\nTerminal resized to %dx%d\n", width, height)
 	return nil

--- a/pkg/sshutil/terminal_windows.go
+++ b/pkg/sshutil/terminal_windows.go
@@ -1,0 +1,111 @@
+//go:build windows
+// +build windows
+
+package sshutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"golang.org/x/term"
+)
+
+// TerminalSession manages input/output streams with terminal state control.
+type TerminalSession struct {
+	stdin    io.Writer
+	stdout   io.Reader
+	stderr   io.Reader
+	fd       int
+	origTerm *term.State
+}
+
+// NewTerminalSession creates and returns a TerminalSession.
+func NewTerminalSession(stdin io.Writer, stdout, stderr io.Reader) (*TerminalSession, error) {
+	fd := int(os.Stdin.Fd())
+	origTerm, err := term.GetState(fd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get terminal state: %w", err)
+	}
+	return &TerminalSession{
+		stdin:    stdin,
+		stdout:   stdout,
+		stderr:   stderr,
+		fd:       fd,
+		origTerm: origTerm,
+	}, nil
+}
+
+// Start activates the terminal session, manages raw mode and I/O streaming.
+// Similar to the Unix implementation but without signal handling.
+func (ts *TerminalSession) Start() error {
+	// Set terminal to raw mode
+	if _, err := term.MakeRaw(ts.fd); err != nil {
+		return fmt.Errorf("failed to set terminal to raw mode: %w", err)
+	}
+
+	// Create a channel to signal when to exit and restore terminal
+	doneCh := make(chan struct{})
+
+	// Create a mutex to prevent terminal state from being restored multiple times
+	var restoreMutex sync.Mutex
+	var alreadyRestored bool
+
+	safeRestore := func() {
+		restoreMutex.Lock()
+		defer restoreMutex.Unlock()
+		if !alreadyRestored {
+			term.Restore(ts.fd, ts.origTerm)
+			alreadyRestored = true
+		}
+	}
+
+	// Create error channel for propagating errors
+	errCh := make(chan error, 3)
+
+	// Handle stdin
+	go func() {
+		_, err := io.Copy(ts.stdin, os.Stdin)
+		if err != nil && err != io.EOF {
+			errCh <- err
+		}
+		// Signal completion
+		close(doneCh)
+	}()
+
+	// Handle stdout
+	go func() {
+		_, err := io.Copy(os.Stdout, ts.stdout)
+		if err != nil && err != io.EOF {
+			errCh <- err
+		}
+		// When stdout ends (SSH connection terminates), restore terminal
+		safeRestore()
+		// Signal completion
+		close(doneCh)
+	}()
+
+	// Handle stderr
+	go func() {
+		_, err := io.Copy(os.Stderr, ts.stderr)
+		if err != nil && err != io.EOF {
+			errCh <- err
+		}
+	}()
+
+	// Wait for either an error or completion signal
+	select {
+	case err := <-errCh:
+		safeRestore()
+		return err
+	case <-doneCh:
+		safeRestore()
+		return nil
+	}
+}
+
+// GetTerminalSize returns the current terminal width and height.
+func GetTerminalSize() (width, height int, err error) {
+	return term.GetSize(int(os.Stdin.Fd()))
+}


### PR DESCRIPTION
## Bitwarden Integration and Cross-Platform SSH Improvements

### Summary

This pull request brings full Bitwarden integration to `ssh-x-term`, enabling secure storage and retrieval of SSH credentials via the Bitwarden CLI. It also adds advanced support for password-based SSH logins both on Unix (with `sshpass`) and Windows (with `plink.exe`), improving cross-platform usability.

### Features

- **Bitwarden Integration**
  - Save, retrieve, update, and delete SSH connection entries using Bitwarden vaults.
  - Use the Bitwarden CLI (`bw`) for all operations, ensuring zero-knowledge security.
  - Team and user sharing support via Bitwarden's organization features.

- **Password-based SSH Login Automation**
  - On Unix, uses `sshpass` to provide passwords securely and non-interactively.
  - On Windows, uses `plink.exe` (from PuTTY) to perform password-based logins.

- **Prerequisites and Compatibility**
  - Works in tmux (or without), supports Bubble Tea TUI.
  - Requires: Bitwarden CLI (`bw`), `sshpass` (Unix), `tmux` (recommended), `plink.exe` (Windows, optional for password auth).

### Prerequisites

- Bitwarden CLI (`bw`)
- `sshpass` (Unix-based systems)
- `tmux` (recommended for terminal multiplexing)
- `plink.exe` (Windows, for password SSH)

### Usage

1. Ensure all prerequisites are installed and available in your PATH.
2. Run `ssh-x-term`. Authenticate to Bitwarden when prompted.
3. Manage SSH connections via the TUI; credentials are securely stored/retrieved using Bitwarden.

### Notes

- Bitwarden credentials are never stored unencrypted.
- Passwords are supplied inline only via secure subprocess execution (`sshpass`, `plink.exe`);

Closes #3 (Bitwarden integration)