### PR TITLE
fix: bug in loading connections of personal vault

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -135,7 +135,11 @@ func loadConnectionsCmd(backend config.Storage) tea.Cmd {
 			}
 			return LoadConnectionsFinishedMsg{Connections: cm.ListConnections()}
 		} else if bw, ok := backend.(*config.BitwardenManager); ok {
-			err = bw.LoadConnectionsByCollectionId(bw.GetSelectedCollection().ID)
+			if bw.IsPersonalVault() {
+				err = bw.Load()
+			} else {
+				err = bw.LoadConnectionsByCollectionId(bw.GetSelectedCollection().ID)
+			}
 			if err != nil {
 				return LoadConnectionsFinishedMsg{Err: err}
 			}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -267,7 +267,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, tea.Batch(cmds...)
 				case key.Matches(msg, key.NewBinding(key.WithKeys("o"))):
 					// Toggle open personal SSH connections
-					m.bitwardenManager.SetPersonalVault(true)
 					cmd := m.loadPersonalVaultConnections()
 					cmds = append(cmds, cmd)
 					return m, tea.Batch(cmds...)


### PR DESCRIPTION
Fix logic typo that misses the case of not loading normally the connections when loading personal connections of personal vault