### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       new_tag: ${{ steps.tag_step.outputs.new_tag }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/eugeniofciuvasile/ssh-x-term/security/code-scanning/1](https://github.com/eugeniofciuvasile/ssh-x-term/security/code-scanning/1)

To fix this problem, add a `permissions` block with the minimal necessary scopes for the `release` job in `.github/workflows/go.yml`. Since the release job performs Git operations (push/commit/tag) and creates a GitHub release, it minimally requires `contents: write` (for pushing git changes/tags and creating releases). To future-proof and adhere to least privilege, do not grant extra permissions. The permissions block should be placed under the `release` job at the same indentation level as `runs-on`. No other regions require changes, as the `publish-npm` job already declares an appropriate permissions block.

- Add (at line 13, just after `runs-on: ubuntu-latest`) the following:
  ```yaml
    permissions:
      contents: write
  ```

No imports or code expressions are needed, as this is a YAML configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
