### PR TITLE
fix(terminal): remove ICANON setting

### DIFF
--- a/internal/ssh/interactive_unix.go
+++ b/internal/ssh/interactive_unix.go
@@ -89,7 +89,6 @@ func ConnectInteractive(connConfig config.SSHConnection) error {
 		ssh.ECHO:          1,
 		ssh.TTY_OP_ISPEED: 14400,
 		ssh.TTY_OP_OSPEED: 14400,
-		ssh.ICANON:        0,
 		ssh.ISIG:          1,
 	}
 

--- a/internal/ssh/interactive_windows.go
+++ b/internal/ssh/interactive_windows.go
@@ -87,7 +87,6 @@ func ConnectInteractive(connConfig config.SSHConnection) error {
 		ssh.ECHO:          1,
 		ssh.TTY_OP_ISPEED: 14400,
 		ssh.TTY_OP_OSPEED: 14400,
-		ssh.ICANON:        0,
 		ssh.ISIG:          1,
 	}
 

--- a/internal/ssh/session_bubbletea_unix.go
+++ b/internal/ssh/session_bubbletea_unix.go
@@ -46,7 +46,6 @@ func NewBubbleTeaSession(connConfig config.SSHConnection, width, height int) (*B
 		ssh.ECHO:          1, // Echo input characters
 		ssh.TTY_OP_ISPEED: 14400,
 		ssh.TTY_OP_OSPEED: 14400,
-		ssh.ICANON:        0, // Disable canonical mode for proper arrow key handling
 		ssh.ISIG:          1, // Enable signal generation (Ctrl+C, etc.)
 	}
 

--- a/internal/ssh/session_bubbletea_windows.go
+++ b/internal/ssh/session_bubbletea_windows.go
@@ -46,7 +46,6 @@ func NewBubbleTeaSession(connConfig config.SSHConnection, width, height int) (*B
 		ssh.ECHO:          1, // Echo input characters
 		ssh.TTY_OP_ISPEED: 14400,
 		ssh.TTY_OP_OSPEED: 14400,
-		ssh.ICANON:        0, // Disable canonical mode for proper arrow key handling
 		ssh.ISIG:          1, // Enable signal generation (Ctrl+C, etc.)
 	}
 


### PR DESCRIPTION
Removing the disabled ICANON setting from our ssh session, it allows for proper prompts handling inputs.