### PR TITLE
64 featui enhance interface with new commands

### DIFF
--- a/internal/config/bitwarden.go
+++ b/internal/config/bitwarden.go
@@ -199,6 +199,17 @@ func (bwm *BitwardenManager) Load() error {
 					if strings.ToLower(name) == "use_password" {
 						conn.UsePassword = value == "true"
 					}
+					if strings.ToLower(name) == "sudo_password" {
+						conn.SudoPassword = value
+					}
+					if strings.ToLower(name) == "pinned" {
+						conn.Pinned = value == "true"
+					}
+					if strings.ToLower(name) == "order" {
+						if o, err := strconv.Atoi(value); err == nil {
+							conn.Order = o
+						}
+					}
 				}
 			}
 		}
@@ -288,6 +299,21 @@ func (bwm *BitwardenManager) AddConnectionInCollectionAndOrganization(conn SSHCo
 		{
 			"name":  "use_password",
 			"value": strconv.FormatBool(conn.UsePassword),
+			"type":  0,
+		},
+		{
+			"name":  "sudo_password",
+			"value": conn.SudoPassword,
+			"type":  1, // Hidden
+		},
+		{
+			"name":  "pinned",
+			"value": strconv.FormatBool(conn.Pinned),
+			"type":  0,
+		},
+		{
+			"name":  "order",
+			"value": strconv.Itoa(conn.Order),
 			"type":  0,
 		},
 	}
@@ -405,6 +431,21 @@ func (bwm *BitwardenManager) EditConnection(conn SSHConnection) error {
 		{
 			"name":  "use_password",
 			"value": strconv.FormatBool(conn.UsePassword),
+			"type":  0,
+		},
+		{
+			"name":  "sudo_password",
+			"value": conn.SudoPassword,
+			"type":  1, // Hidden
+		},
+		{
+			"name":  "pinned",
+			"value": strconv.FormatBool(conn.Pinned),
+			"type":  0,
+		},
+		{
+			"name":  "order",
+			"value": strconv.Itoa(conn.Order),
 			"type":  0,
 		},
 	}
@@ -660,6 +701,17 @@ func (bwm *BitwardenManager) LoadConnectionsByCollectionId(collectionId string) 
 					value, _ := field["value"].(string)
 					if strings.ToLower(name) == "use_password" {
 						conn.UsePassword = value == "true"
+					}
+					if strings.ToLower(name) == "sudo_password" {
+						conn.SudoPassword = value
+					}
+					if strings.ToLower(name) == "pinned" {
+						conn.Pinned = value == "true"
+					}
+					if strings.ToLower(name) == "order" {
+						if o, err := strconv.Atoi(value); err == nil {
+							conn.Order = o
+						}
 					}
 				}
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,16 @@ func (cm *ConfigManager) AddConnection(conn SSHConnection) error {
 		conn.Password = ""
 	}
 
+	// Handle sudo password securely using keyring
+	if conn.SudoPassword != "" {
+		if err := keyring.Set(keyringService, "sudo:"+conn.ID, conn.SudoPassword); err != nil {
+			log.Printf("Failed to store sudo password in keyring: %v", err)
+			return err
+		}
+		// Unset sudo password in plaintext config
+		conn.SudoPassword = ""
+	}
+
 	for i, existing := range cm.Config.Connections {
 		if existing.ID == conn.ID {
 			cm.Config.Connections[i] = conn
@@ -79,6 +89,16 @@ func (cm *ConfigManager) EditConnection(conn SSHConnection) error {
 		conn.Password = ""
 	}
 
+	// Handle sudo password securely using keyring
+	if conn.SudoPassword != "" {
+		if err := keyring.Set(keyringService, "sudo:"+conn.ID, conn.SudoPassword); err != nil {
+			log.Printf("Failed to store sudo password in keyring: %v", err)
+			return err
+		}
+		// Unset sudo password in plaintext config
+		conn.SudoPassword = ""
+	}
+
 	for i, existing := range cm.Config.Connections {
 		if existing.ID == conn.ID {
 			cm.Config.Connections[i] = conn
@@ -94,6 +114,11 @@ func (cm *ConfigManager) DeleteConnection(id string) error {
 	// Remove password from keyring
 	if err := keyring.Delete(keyringService, id); err != nil {
 		log.Printf("Failed to delete password from keyring (may not exist): %v", err)
+	}
+
+	// Remove sudo password from keyring
+	if err := keyring.Delete(keyringService, "sudo:"+id); err != nil {
+		log.Printf("Failed to delete sudo password from keyring (may not exist): %v", err)
 	}
 
 	for i, conn := range cm.Config.Connections {
@@ -126,6 +151,16 @@ func (cm *ConfigManager) GetConnection(id string) (SSHConnection, bool) {
 				conn.Password = password
 				log.Printf("Retrieved password from keyring for connection ID: %s (key: %s)", id, keyringKey)
 			}
+
+			// Retrieve sudo password from keyring
+			sudoPassword, err := keyring.Get(keyringService, "sudo:"+id)
+			if err != nil {
+				log.Printf("Failed to retrieve sudo password from keyring (key: %s): %v", "sudo:"+id, err)
+			} else {
+				conn.SudoPassword = sudoPassword
+				log.Printf("Retrieved sudo password from keyring for connection ID: %s", id)
+			}
+
 			return conn, true
 		}
 	}

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -67,6 +67,12 @@ func MigrateFromJSON() error {
 			conn.Password = password
 		}
 
+		// Try to retrieve sudo password from old keyring
+		sudoPassword, err := keyring.Get(legacyKeyringService, "sudo:"+conn.ID)
+		if err == nil && sudoPassword != "" {
+			conn.SudoPassword = sudoPassword
+		}
+
 		// Add connection to SSH config
 		if err := scm.AddConnection(conn); err != nil {
 			log.Printf("Warning: failed to migrate connection %s (%s): %v", conn.Name, conn.ID, err)

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -9,12 +9,15 @@ type SSHConnection struct {
 	Port           int      `json:"port"`
 	Username       string   `json:"username"`
 	Password       string   `json:"password,omitempty"`
+	SudoPassword   string   `json:"sudo_password,omitempty"`
 	PublicKey      string   `json:"public_key,omitempty"`
 	UsePassword    bool     `json:"use_password"`
 	KeyFile        string   `json:"key_file,omitempty"`
 	Notes          string   `json:"notes,omitempty"`
 	OrganizationID string   `json:"organizationId"`
 	CollectionIds  []string `json:"collectionIds,omitempty"`
+	Pinned         bool     `json:"pinned"`
+	Order          int      `json:"order"`
 }
 
 // Organization represents the user's organization

--- a/internal/config/sshconfig.go
+++ b/internal/config/sshconfig.go
@@ -141,6 +141,14 @@ func (scm *SSHConfigManager) parseSSHConfig() error {
 				if orgID, ok := sxtMetadata["organization_id"]; ok {
 					currentConn.OrganizationID = orgID
 				}
+				if pinned, ok := sxtMetadata["pinned"]; ok {
+					currentConn.Pinned = pinned == "true"
+				}
+				if order, ok := sxtMetadata["order"]; ok {
+					if o, err := strconv.Atoi(order); err == nil {
+						currentConn.Order = o
+					}
+				}
 			}
 
 			// Generate ID if not set
@@ -230,6 +238,12 @@ func (scm *SSHConfigManager) writeSSHConfig() error {
 			conn.Password = "" // Don't keep in memory
 		}
 
+		// Store sudo password if it exists
+		if conn.SudoPassword != "" {
+			keyring.Set(sshKeyringService, "sudo:"+conn.ID, conn.SudoPassword)
+			conn.SudoPassword = "" // Don't keep in memory
+		}
+
 		// Write metadata comments
 		fmt.Fprintf(writer, "%sid=%s\n", sxtCommentPrefix, conn.ID)
 		if conn.Name != "" {
@@ -244,6 +258,12 @@ func (scm *SSHConfigManager) writeSSHConfig() error {
 		}
 		if conn.OrganizationID != "" {
 			fmt.Fprintf(writer, "%sorganization_id=%s\n", sxtCommentPrefix, conn.OrganizationID)
+		}
+		if conn.Pinned {
+			fmt.Fprintf(writer, "%spinned=true\n", sxtCommentPrefix)
+		}
+		if conn.Order != 0 {
+			fmt.Fprintf(writer, "%sorder=%d\n", sxtCommentPrefix, conn.Order)
 		}
 
 		// Write SSH config
@@ -291,6 +311,15 @@ func (scm *SSHConfigManager) AddConnection(conn SSHConnection) error {
 		conn.Password = ""
 	}
 
+	// Handle sudo password securely using keyring
+	if conn.SudoPassword != "" {
+		if err := keyring.Set(sshKeyringService, "sudo:"+conn.ID, conn.SudoPassword); err != nil {
+			log.Printf("Failed to store sudo password in keyring: %v", err)
+			return err
+		}
+		conn.SudoPassword = ""
+	}
+
 	// Check if connection already exists
 	for i, existing := range scm.Config.Connections {
 		if existing.ID == conn.ID {
@@ -314,6 +343,15 @@ func (scm *SSHConfigManager) EditConnection(conn SSHConnection) error {
 		conn.Password = ""
 	}
 
+	// Handle sudo password securely using keyring
+	if conn.SudoPassword != "" {
+		if err := keyring.Set(sshKeyringService, "sudo:"+conn.ID, conn.SudoPassword); err != nil {
+			log.Printf("Failed to store sudo password in keyring: %v", err)
+			return err
+		}
+		conn.SudoPassword = ""
+	}
+
 	for i, existing := range scm.Config.Connections {
 		if existing.ID == conn.ID {
 			scm.Config.Connections[i] = conn
@@ -330,6 +368,11 @@ func (scm *SSHConfigManager) DeleteConnection(id string) error {
 	// Remove password from keyring
 	if err := keyring.Delete(sshKeyringService, id); err != nil {
 		log.Printf("Failed to delete password from keyring (may not exist): %v", err)
+	}
+
+	// Remove sudo password from keyring
+	if err := keyring.Delete(sshKeyringService, "sudo:"+id); err != nil {
+		log.Printf("Failed to delete sudo password from keyring (may not exist): %v", err)
 	}
 
 	for i, conn := range scm.Config.Connections {
@@ -363,6 +406,16 @@ func (scm *SSHConfigManager) GetConnection(id string) (SSHConnection, bool) {
 				conn.Password = password
 				log.Printf("Retrieved password from keyring for connection ID: %s (key: %s)", id, keyringKey)
 			}
+
+			// Retrieve sudo password from keyring
+			sudoPassword, err := keyring.Get(sshKeyringService, "sudo:"+id)
+			if err != nil {
+				log.Printf("Failed to retrieve sudo password from keyring (key: %s): %v", "sudo:"+id, err)
+			} else {
+				conn.SudoPassword = sudoPassword
+				log.Printf("Retrieved sudo password from keyring for connection ID: %s", id)
+			}
+
 			return conn, true
 		}
 	}

--- a/internal/config/sshconfig_test.go
+++ b/internal/config/sshconfig_test.go
@@ -140,13 +140,14 @@ func TestSSHConfigWriting(t *testing.T) {
 
 	// Add a connection
 	conn := SSHConnection{
-		ID:          "test-write-1",
-		Name:        "Write Test",
-		Host:        "writetest.example.com",
-		Port:        22,
-		Username:    "writeuser",
-		UsePassword: true,
-		Notes:       "Write test notes",
+		ID:           "test-write-1",
+		Name:         "Write Test",
+		Host:         "writetest.example.com",
+		Port:         22,
+		Username:     "writeuser",
+		UsePassword:  true,
+		SudoPassword: "sudo-test-pass",
+		Notes:        "Write test notes",
 	}
 
 	if err := scm.AddConnection(conn); err != nil {
@@ -170,6 +171,15 @@ func TestSSHConfigWriting(t *testing.T) {
 
 	if connections[0].Name != "Write Test" {
 		t.Errorf("Expected name 'Write Test', got '%s'", connections[0].Name)
+	}
+
+	// Verify sudo password was retrieved (via GetConnection as ListConnections doesn't include it for security in some managers, but SSHConfigManager.Load parses it from config if it was there? No, it's in keyring)
+	fullConn, ok := scm2.GetConnection("test-write-1")
+	if !ok {
+		t.Fatal("Failed to get full connection")
+	}
+	if fullConn.SudoPassword != "sudo-test-pass" {
+		t.Errorf("Expected sudo password 'sudo-test-pass', got '%s'", fullConn.SudoPassword)
 	}
 }
 

--- a/internal/ui/components/connection_list.go
+++ b/internal/ui/components/connection_list.go
@@ -3,6 +3,7 @@ package components
 import (
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
@@ -17,11 +18,28 @@ type DeleteConnectionMsg struct {
 	Connection config.SSHConnection
 }
 
+type RenameConnectionMsg struct {
+	Connection config.SSHConnection
+	NewName    string
+}
+
+type TogglePinnedMsg struct {
+	Connection config.SSHConnection
+}
+
+type MoveConnectionUpMsg struct {
+	Connection config.SSHConnection
+}
+
+type MoveConnectionDownMsg struct {
+	Connection config.SSHConnection
+}
+
 type connectionItem struct {
 	connection config.SSHConnection
 }
 
-func (i connectionItem) FilterValue() string { return i.connection.Name }
+func (i connectionItem) FilterValue() string { return i.connection.Name + " " + i.connection.Host }
 
 // connectionDelegate handles the rendering of each list item with dynamic widths
 type connectionDelegate struct {
@@ -55,7 +73,11 @@ func (d connectionDelegate) Render(w io.Writer, m list.Model, index int, listIte
 	}
 
 	// Format columns using the dynamic widths stored in the delegate
-	name := truncate(conn.Name, d.nameWidth)
+	name := conn.Name
+	if conn.Pinned {
+		name = "📌 " + name
+	}
+	name = truncate(name, d.nameWidth)
 	host := truncate(conn.Host, d.hostWidth)
 	user := truncate(conn.Username, d.userWidth)
 	port := truncate(fmt.Sprintf("%d", conn.Port), d.portWidth)
@@ -94,7 +116,7 @@ func truncate(s string, max int) string {
 
 type ConnectionList struct {
 	list              list.Model
-	connections       []config.SSHConnection
+	Connections       []config.SSHConnection
 	selectedConn      *config.SSHConnection
 	highlightedConn   *config.SSHConnection
 	openInNewTerminal bool
@@ -108,13 +130,47 @@ type ConnectionList struct {
 	showPasswordModal bool
 	passwordModal     *PasswordModal
 
+	// Rename modal
+	showRenameModal bool
+	renameModal     *RenameModal
+
 	// layout stores the current column widths for header rendering
 	layout connectionDelegate
 }
 
+func sortConnections(connections []config.SSHConnection) []config.SSHConnection {
+	sorted := make([]config.SSHConnection, len(connections))
+	copy(sorted, connections)
+	slices.SortStableFunc(sorted, func(a, b config.SSHConnection) int {
+		if a.Pinned && !b.Pinned {
+			return -1
+		}
+		if !a.Pinned && b.Pinned {
+			return 1
+		}
+		// If both have same pinned status, sort by order
+		if a.Order < b.Order {
+			return -1
+		}
+		if a.Order > b.Order {
+			return 1
+		}
+		// If order is same, sort by name
+		if a.Name < b.Name {
+			return -1
+		}
+		if a.Name > b.Name {
+			return 1
+		}
+		return 0
+	})
+	return sorted
+}
+
 func NewConnectionList(connections []config.SSHConnection) *ConnectionList {
-	items := make([]list.Item, len(connections))
-	for i, conn := range connections {
+	sorted := sortConnections(connections)
+	items := make([]list.Item, len(sorted))
+	for i, conn := range sorted {
 		items[i] = connectionItem{connection: conn}
 	}
 
@@ -131,13 +187,13 @@ func NewConnectionList(connections []config.SSHConnection) *ConnectionList {
 	l.Styles.PaginationStyle = paginationStyle
 
 	var highlighted *config.SSHConnection
-	if len(connections) > 0 {
-		highlighted = &connections[0]
+	if len(sorted) > 0 {
+		highlighted = &sorted[0]
 	}
 
 	cl := &ConnectionList{
 		list:              l,
-		connections:       connections,
+		Connections:       sorted,
 		highlightedConn:   highlighted,
 		openInNewTerminal: config.IsTmuxAvailable,
 		layout:            defaultDelegate,
@@ -193,6 +249,31 @@ func (cl *ConnectionList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return cl, cmd
 	}
 
+	// If rename modal is showing, delegate to it
+	if cl.showRenameModal && cl.renameModal != nil {
+		var modalModel tea.Model
+		modalModel, cmd = cl.renameModal.Update(msg)
+		cl.renameModal = modalModel.(*RenameModal)
+
+		if cl.renameModal.IsConfirmed() {
+			cl.showRenameModal = false
+			if cl.highlightedConn != nil {
+				renameMsg := RenameConnectionMsg{
+					Connection: *cl.highlightedConn,
+					NewName:    cl.renameModal.Value(),
+				}
+				cl.renameModal = nil
+				return cl, func() tea.Msg { return renameMsg }
+			}
+			cl.renameModal = nil
+		} else if cl.renameModal.IsCanceled() {
+			cl.showRenameModal = false
+			cl.renameModal = nil
+		}
+
+		return cl, cmd
+	}
+
 	switch msg := msg.(type) {
 	case ToggleOpenInNewTerminalMsg:
 		return cl, nil
@@ -206,6 +287,10 @@ func (cl *ConnectionList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Also update password modal if it exists
 		if cl.passwordModal != nil {
 			cl.passwordModal.SetSize(msg.Width, msg.Height)
+		}
+		// Also update rename modal if it exists
+		if cl.renameModal != nil {
+			cl.renameModal.SetSize(msg.Width, msg.Height)
 		}
 		return cl, nil
 
@@ -249,7 +334,7 @@ func (cl *ConnectionList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (cl *ConnectionList) View() string {
-	if len(cl.connections) == 0 {
+	if len(cl.Connections) == 0 {
 		// Simplified message since global title handles context
 		return "\n\n  No connections found. Press 'a' to add a connection.\n\n"
 	}
@@ -303,6 +388,20 @@ func (cl *ConnectionList) View() string {
 		)
 	}
 
+	// If rename modal is showing, overlay it on top
+	if cl.showRenameModal && cl.renameModal != nil {
+		modalView := cl.renameModal.View()
+		return lipgloss.Place(
+			cl.list.Width(),
+			cl.list.Height(),
+			lipgloss.Center,
+			lipgloss.Center,
+			modalView,
+			lipgloss.WithWhitespaceChars(" "),
+			lipgloss.WithWhitespaceForeground(lipgloss.Color("0")),
+		)
+	}
+
 	return listView
 }
 
@@ -324,19 +423,86 @@ func (cl *ConnectionList) IsShowingPasswordModal() bool {
 	return cl.showPasswordModal
 }
 
-func (cl *ConnectionList) ShowPassword(password string) {
-	cl.passwordModal = NewPasswordModal(password)
+func (cl *ConnectionList) IsShowingRenameModal() bool {
+	return cl.showRenameModal
+}
+
+func (cl *ConnectionList) ShowPassword(conn config.SSHConnection) {
+	entries := []PasswordEntry{}
+	if conn.Password != "" {
+		label := "Password"
+		if !conn.UsePassword {
+			label = "Key Passphrase"
+		}
+		entries = append(entries, PasswordEntry{Label: label, Password: conn.Password})
+	}
+	if conn.SudoPassword != "" {
+		entries = append(entries, PasswordEntry{Label: "Sudo Password", Password: conn.SudoPassword})
+	}
+
+	if len(entries) == 0 {
+		cl.passwordModal = NewPasswordModal("")
+	} else if len(entries) == 1 {
+		cl.passwordModal = NewPasswordModal(entries[0].Password)
+		// Set the label correctly even for single entry
+		cl.passwordModal = NewMultiPasswordModal(entries)
+	} else {
+		cl.passwordModal = NewMultiPasswordModal(entries)
+	}
+
 	cl.passwordModal.SetSize(cl.list.Width(), cl.list.Height())
 	cl.showPasswordModal = true
 }
 
+func (cl *ConnectionList) ShowRename() {
+	if cl.highlightedConn == nil {
+		return
+	}
+	cl.renameModal = NewRenameModal(cl.highlightedConn.Name, cl.highlightedConn.Host)
+	cl.renameModal.SetSize(cl.list.Width(), cl.list.Height())
+	cl.showRenameModal = true
+}
+
+func (cl *ConnectionList) Rename() tea.Cmd {
+	if cl.highlightedConn == nil {
+		return nil
+	}
+	cl.ShowRename()
+	return nil
+}
+
 func (cl *ConnectionList) SetConnections(connections []config.SSHConnection) {
-	cl.connections = connections
-	items := make([]list.Item, len(connections))
-	for i, conn := range connections {
+	sorted := sortConnections(connections)
+	cl.Connections = sorted
+	items := make([]list.Item, len(sorted))
+	for i, conn := range sorted {
 		items[i] = connectionItem{connection: conn}
 	}
 	cl.list.SetItems(items)
+}
+
+func (cl *ConnectionList) TogglePinned() tea.Cmd {
+	if cl.highlightedConn == nil {
+		return nil
+	}
+	conn := *cl.highlightedConn
+	return func() tea.Msg { return TogglePinnedMsg{Connection: conn} }
+}
+
+func (cl *ConnectionList) MoveUp() tea.Cmd {
+	if cl.highlightedConn == nil {
+		return nil
+	}
+	conn := *cl.highlightedConn
+	return func() tea.Msg { return MoveConnectionUpMsg{Connection: conn} }
+}
+
+func (cl *ConnectionList) MoveDown() tea.Cmd {
+	if cl.highlightedConn == nil {
+		return nil
+	}
+	conn := *cl.highlightedConn
+	return func() tea.Msg { return MoveConnectionDownMsg{Connection: conn} }
 }
 
 func (cl *ConnectionList) List() *list.Model { return &cl.list }
@@ -344,8 +510,8 @@ func (cl *ConnectionList) List() *list.Model { return &cl.list }
 func (cl *ConnectionList) Reset() {
 	cl.selectedConn = nil
 	cl.list.Select(0)
-	if len(cl.connections) > 0 {
-		cl.highlightedConn = &cl.connections[0]
+	if len(cl.Connections) > 0 {
+		cl.highlightedConn = &cl.Connections[0]
 	} else {
 		cl.highlightedConn = nil
 	}
@@ -384,8 +550,8 @@ func (cl *ConnectionList) recalculateTableLayout(totalWidth int) {
 	remaining := availableWidth - portW - authW
 
 	// Distribute remaining space:
-	// Name: 35%, Host: 35%, User: 30%
-	nameW := int(float64(remaining) * 0.35)
+	// Name: 40%, Host: 35%, User: 25%
+	nameW := int(float64(remaining) * 0.40)
 	hostW := int(float64(remaining) * 0.35)
 	userW := remaining - nameW - hostW // Give remainder to user to avoid rounding gaps
 

--- a/internal/ui/components/connection_list.go
+++ b/internal/ui/components/connection_list.go
@@ -104,6 +104,10 @@ type ConnectionList struct {
 	deleteConfirm     *DeleteConfirmation
 	pendingDelete     *config.SSHConnection
 
+	// Password modal
+	showPasswordModal bool
+	passwordModal     *PasswordModal
+
 	// layout stores the current column widths for header rendering
 	layout connectionDelegate
 }
@@ -175,6 +179,20 @@ func (cl *ConnectionList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return cl, cmd
 	}
 
+	// If password modal is showing, delegate to it
+	if cl.showPasswordModal && cl.passwordModal != nil {
+		var modalModel tea.Model
+		modalModel, cmd = cl.passwordModal.Update(msg)
+		cl.passwordModal = modalModel.(*PasswordModal)
+
+		if cl.passwordModal.IsCanceled() {
+			cl.showPasswordModal = false
+			cl.passwordModal = nil
+		}
+
+		return cl, cmd
+	}
+
 	switch msg := msg.(type) {
 	case ToggleOpenInNewTerminalMsg:
 		return cl, nil
@@ -184,6 +202,10 @@ func (cl *ConnectionList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Also update delete confirmation if it exists
 		if cl.deleteConfirm != nil {
 			cl.deleteConfirm.SetSize(msg.Width, msg.Height)
+		}
+		// Also update password modal if it exists
+		if cl.passwordModal != nil {
+			cl.passwordModal.SetSize(msg.Width, msg.Height)
 		}
 		return cl, nil
 
@@ -267,6 +289,20 @@ func (cl *ConnectionList) View() string {
 		)
 	}
 
+	// If password modal is showing, overlay it on top
+	if cl.showPasswordModal && cl.passwordModal != nil {
+		modalView := cl.passwordModal.View()
+		return lipgloss.Place(
+			cl.list.Width(),
+			cl.list.Height(),
+			lipgloss.Center,
+			lipgloss.Center,
+			modalView,
+			lipgloss.WithWhitespaceChars(" "),
+			lipgloss.WithWhitespaceForeground(lipgloss.Color("0")),
+		)
+	}
+
 	return listView
 }
 
@@ -282,6 +318,16 @@ func (cl *ConnectionList) ToggleOpenInNewTerminal() {
 
 func (cl *ConnectionList) IsShowingDeleteConfirm() bool {
 	return cl.showDeleteConfirm
+}
+
+func (cl *ConnectionList) IsShowingPasswordModal() bool {
+	return cl.showPasswordModal
+}
+
+func (cl *ConnectionList) ShowPassword(password string) {
+	cl.passwordModal = NewPasswordModal(password)
+	cl.passwordModal.SetSize(cl.list.Width(), cl.list.Height())
+	cl.showPasswordModal = true
 }
 
 func (cl *ConnectionList) SetConnections(connections []config.SSHConnection) {

--- a/internal/ui/components/form.go
+++ b/internal/ui/components/form.go
@@ -57,8 +57,8 @@ func NewConnectionForm(conn *config.SSHConnection) *ConnectionForm {
 	}
 
 	// Create text inputs
-	// 0: Name, 1: Host, 2: Port, 3: User, 4: Pass, 5: Key, 6: ID
-	inputs = make([]textinput.Model, 7)
+	// 0: Name, 1: Host, 2: Port, 3: Username, 4: Key, 5: Password, 6: SudoPassword, 7: ID
+	inputs = make([]textinput.Model, 8)
 
 	// Helper to init standard inputs
 	initInput := func(i int, placeholder string, width int) {
@@ -79,16 +79,21 @@ func NewConnectionForm(conn *config.SSHConnection) *ConnectionForm {
 	initInput(2, "Port (default: 22)", 40)
 	initInput(3, "Username", 30)
 
-	// Password input
-	initInput(4, "Password", 40)
-	inputs[4].EchoMode = textinput.EchoPassword
-	inputs[4].EchoCharacter = '•'
-
 	// Key file input
-	initInput(5, "Path to SSH key (example: ~/.ssh/id_rsa)", 50)
+	initInput(4, "Path to SSH key (example: ~/.ssh/id_rsa)", 50)
+
+	// Password input
+	initInput(5, "Password / Key Passphrase", 40)
+	inputs[5].EchoMode = textinput.EchoPassword
+	inputs[5].EchoCharacter = '•'
+
+	// Sudo password input
+	initInput(6, "Sudo / User Password (optional)", 40)
+	inputs[6].EchoMode = textinput.EchoPassword
+	inputs[6].EchoCharacter = '•'
 
 	// ID input (hidden from view, used as identifier)
-	initInput(6, "ID (auto-generated)", 40)
+	initInput(7, "ID (auto-generated)", 40)
 
 	// If editing, fill the fields
 	if editing {
@@ -96,9 +101,10 @@ func NewConnectionForm(conn *config.SSHConnection) *ConnectionForm {
 		inputs[1].SetValue(initialConn.Host)
 		inputs[2].SetValue(strconv.Itoa(initialConn.Port))
 		inputs[3].SetValue(initialConn.Username)
-		inputs[4].SetValue(initialConn.Password)
-		inputs[5].SetValue(initialConn.KeyFile)
-		inputs[6].SetValue(initialConn.ID)
+		inputs[4].SetValue(initialConn.KeyFile)
+		inputs[5].SetValue(initialConn.Password)
+		inputs[6].SetValue(initialConn.SudoPassword)
+		inputs[7].SetValue(initialConn.ID)
 	}
 
 	// Scan ~/.ssh for private keys (simple scan)
@@ -149,7 +155,7 @@ func (m *ConnectionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Dropdown navigation logic
-		if m.focusIndex == 5 && !m.usePassword && m.dropdownOpen {
+		if m.focusIndex == 4 && !m.usePassword && m.dropdownOpen {
 			switch msg.String() {
 			case "esc":
 				// Close dropdown, stay on field
@@ -161,7 +167,7 @@ func (m *ConnectionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				selected := m.keyList.SelectedItem()
 				if selected != nil {
 					if s, ok := selected.(keyItem); ok {
-						m.inputs[5].SetValue(string(s))
+						m.inputs[4].SetValue(string(s))
 					}
 				}
 				m.dropdownOpen = false
@@ -182,11 +188,11 @@ func (m *ConnectionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			// Handle typing in the field while dropdown is open (Filtering)
 			if isPrintableKey(msg) {
-				newTi, cmd := m.inputs[5].Update(msg)
-				m.inputs[5] = newTi
+				newTi, cmd := m.inputs[4].Update(msg)
+				m.inputs[4] = newTi
 				cmds = append(cmds, cmd)
 
-				cur := strings.TrimSpace(m.inputs[5].Value())
+				cur := strings.TrimSpace(m.inputs[4].Value())
 
 				// If field is empty after backspace, reopen dropdown with all keys
 				if cur == "" {
@@ -221,13 +227,13 @@ func (m *ConnectionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Handle backspace
-		if m.focusIndex == 5 && !m.usePassword && !m.dropdownOpen {
+		if m.focusIndex == 4 && !m.usePassword && !m.dropdownOpen {
 			if msg.String() == "backspace" || msg.String() == "delete" {
-				newTi, cmd := m.inputs[5].Update(msg)
-				m.inputs[5] = newTi
+				newTi, cmd := m.inputs[4].Update(msg)
+				m.inputs[4] = newTi
 				cmds = append(cmds, cmd)
 
-				cur := strings.TrimSpace(m.inputs[5].Value())
+				cur := strings.TrimSpace(m.inputs[4].Value())
 
 				// If field is empty after backspace, reopen dropdown with all keys
 				if cur == "" {
@@ -259,47 +265,41 @@ func (m *ConnectionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				step = -1
 			}
 
-			// Move focus
-			m.focusIndex += step
+			// Move focus with robust skipping
+			for i := 0; i < len(m.inputs)+2; i++ {
+				m.focusIndex += step
 
-			// Handle skipping logic
-			// Indices: 0=Name, 1=Host, 2=Port, 3=User, 4=Pass, 5=Key, 6=ID(Hidden), 7=SubmitButton
+				// Handle Wrap-around
+				if m.focusIndex > 8 {
+					m.focusIndex = 0
+				} else if m.focusIndex < 0 {
+					m.focusIndex = 8
+				}
 
-			// Skip Password(4) if using Key
-			if !m.usePassword && m.focusIndex == 4 {
-				m.focusIndex += step
-			}
-			// Skip Key(5) if using Password
-			if m.usePassword && m.focusIndex == 5 {
-				m.focusIndex += step
-			}
-			// Skip ID(6) always
-			if m.focusIndex == 6 {
-				m.focusIndex += step
-			}
+				// Check if we should stop at this index
+				// 0-3: Always stop
+				// 4: Only stop if !usePassword (Key File)
+				// 5: Always stop (Password/Passphrase)
+				// 6: Always stop (Sudo Password)
+				// 7: Always skip (ID)
+				// 8: Always stop (Submit)
 
-			// Handle Wrap-around
-			if m.focusIndex > 7 {
-				m.focusIndex = 0
-			} else if m.focusIndex < 0 {
-				m.focusIndex = 7
-			}
+				shouldSkip := false
+				if m.focusIndex == 7 {
+					shouldSkip = true
+				} else if m.focusIndex == 4 && m.usePassword {
+					shouldSkip = true
+				}
 
-			// Re-check skip logic after wrap-around
-			if m.focusIndex == 6 {
-				m.focusIndex += step
-			}
-			if m.usePassword && m.focusIndex == 5 {
-				m.focusIndex += step
-			}
-			if !m.usePassword && m.focusIndex == 4 {
-				m.focusIndex += step
+				if !shouldSkip {
+					break
+				}
 			}
 
-			if m.focusIndex == 5 && !m.usePassword {
+			if m.focusIndex == 4 && !m.usePassword {
 				m.dropdownOpen = true
 				// Reset list to full view initially or filtered by existing text
-				cur := m.inputs[5].Value()
+				cur := m.inputs[4].Value()
 				filtered := filterKeys(m.allKeys, cur)
 				items := make([]list.Item, 0, len(filtered))
 				for _, k := range filtered {
@@ -325,8 +325,8 @@ func (m *ConnectionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "enter":
-			// Check if we are at the submit button (index 7) OR submitting from a field
-			if m.focusIndex == 7 {
+			// Check if we are at the submit button (index 8) OR submitting from a field
+			if m.focusIndex == 8 {
 				if valid, err := m.validateForm(); valid {
 					m.updateConnection()
 					m.submitted = true
@@ -344,14 +344,14 @@ func (m *ConnectionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.dropdownOpen = false
 
 			// Adjust focus if currently on the toggleable field
-			if m.usePassword && m.focusIndex == 5 {
-				m.focusIndex = 4
-				m.inputs[5].Blur()
-				m.inputs[4].Focus()
-			} else if !m.usePassword && m.focusIndex == 4 {
+			if m.usePassword && m.focusIndex == 4 {
 				m.focusIndex = 5
 				m.inputs[4].Blur()
 				m.inputs[5].Focus()
+			} else if !m.usePassword && m.focusIndex == 5 {
+				m.focusIndex = 4
+				m.inputs[5].Blur()
+				m.inputs[4].Focus()
 				// Auto-open if we switched into key field
 				m.dropdownOpen = true
 			}
@@ -361,8 +361,8 @@ func (m *ConnectionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Handle character input for standard fields
 	// (Key field handled separately in dropdown block if open, but we update it here if closed or fallback)
 	if m.focusIndex < len(m.inputs) {
-		// Avoid double update for index 5 if we already handled it in dropdown block
-		if kmsg, ok := msg.(tea.KeyMsg); ok && m.focusIndex == 5 && m.dropdownOpen && isPrintableKey(kmsg) {
+		// Avoid double update for index 4 if we already handled it in dropdown block
+		if kmsg, ok := msg.(tea.KeyMsg); ok && m.focusIndex == 4 && m.dropdownOpen && isPrintableKey(kmsg) {
 			// already handled
 		} else {
 			newInput, cmd := m.inputs[m.focusIndex].Update(msg)
@@ -414,10 +414,10 @@ func (m *ConnectionForm) View() string {
 
 	// Render conditional input
 	if m.usePassword {
-		b.WriteString(m.inputs[4].View()) // Password
+		b.WriteString(m.inputs[5].View()) // Password
 	} else {
 		// SSH Key input
-		b.WriteString(m.inputs[5].View())
+		b.WriteString(m.inputs[4].View())
 
 		// Render dropdown under SSH key input
 		if m.dropdownOpen {
@@ -429,12 +429,21 @@ func (m *ConnectionForm) View() string {
 				Render(m.keyList.View())
 			b.WriteString("\n" + dropdownBox)
 		}
+
+		// Also show key passphrase field if it's not empty or focused
+		b.WriteString("\n\n")
+		b.WriteString(label("Key Passphrase (optional)") + "\n")
+		b.WriteString(m.inputs[5].View())
 	}
 	b.WriteString("\n\n")
 
-	// Render submit button (Index 7)
+	// Sudo password field
+	b.WriteString(label("Sudo / User Password (optional)") + "\n")
+	b.WriteString(m.inputs[6].View() + "\n\n")
+
+	// Render submit button (Index 8)
 	button := blurredButton
-	if m.focusIndex == 7 {
+	if m.focusIndex == 8 {
 		button = focusedButton
 	}
 	b.WriteString(button)
@@ -507,7 +516,7 @@ func (m *ConnectionForm) validateForm() (bool, string) {
 	}
 
 	// If using key authentication, key path must not be empty
-	if !m.usePassword && strings.TrimSpace(m.inputs[5].Value()) == "" {
+	if !m.usePassword && strings.TrimSpace(m.inputs[4].Value()) == "" {
 		return false, "SSH key path is required for key authentication"
 	}
 
@@ -517,11 +526,11 @@ func (m *ConnectionForm) validateForm() (bool, string) {
 // updateConnection updates the connection from the form inputs
 func (m *ConnectionForm) updateConnection() {
 	// Generate ID if not editing
-	id := m.inputs[6].Value()
+	id := m.inputs[7].Value()
 	if id == "" {
 		id = strings.ReplaceAll(m.inputs[0].Value(), " ", "_") + "_" +
 			strconv.FormatInt(time.Now().UnixNano(), 10)
-		m.inputs[6].SetValue(id)
+		m.inputs[7].SetValue(id)
 	}
 
 	// Parse port
@@ -530,17 +539,16 @@ func (m *ConnectionForm) updateConnection() {
 		port, _ = strconv.Atoi(m.inputs[2].Value())
 	}
 
-	// Update connection
-	m.connection = config.SSHConnection{
-		ID:          id,
-		Name:        m.inputs[0].Value(),
-		Host:        m.inputs[1].Value(),
-		Port:        port,
-		Username:    m.inputs[3].Value(),
-		Password:    strings.TrimSpace(m.inputs[4].Value()),
-		KeyFile:     strings.TrimSpace(m.inputs[5].Value()),
-		UsePassword: m.usePassword,
-	}
+	// Update connection fields while preserving metadata
+	m.connection.ID = id
+	m.connection.Name = m.inputs[0].Value()
+	m.connection.Host = m.inputs[1].Value()
+	m.connection.Port = port
+	m.connection.Username = m.inputs[3].Value()
+	m.connection.KeyFile = strings.TrimSpace(m.inputs[4].Value())
+	m.connection.Password = strings.TrimSpace(m.inputs[5].Value())
+	m.connection.SudoPassword = strings.TrimSpace(m.inputs[6].Value())
+	m.connection.UsePassword = m.usePassword
 }
 
 // ---------- Helper functions ----------

--- a/internal/ui/components/password_modal.go
+++ b/internal/ui/components/password_modal.go
@@ -1,6 +1,8 @@
 package components
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/atotto/clipboard"
@@ -8,8 +10,14 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+type PasswordEntry struct {
+	Label    string
+	Password string
+}
+
 type PasswordModal struct {
-	password    string
+	entries     []PasswordEntry
+	index       int
 	copied      bool
 	canceled    bool
 	width       int
@@ -21,7 +29,13 @@ type resetCopiedMsg struct{}
 
 func NewPasswordModal(password string) *PasswordModal {
 	return &PasswordModal{
-		password: password,
+		entries: []PasswordEntry{{Label: "Password", Password: password}},
+	}
+}
+
+func NewMultiPasswordModal(entries []PasswordEntry) *PasswordModal {
+	return &PasswordModal{
+		entries: entries,
 	}
 }
 
@@ -45,13 +59,25 @@ func (m *PasswordModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "up", "k":
+			if m.index > 0 {
+				m.index--
+				m.copied = false
+			}
+		case "down", "j":
+			if m.index < len(m.entries)-1 {
+				m.index++
+				m.copied = false
+			}
 		case "c", "C":
-			err := CopyToClipboard(m.password)
-			if err == nil {
-				m.copied = true
-				return m, tea.Tick(time.Second*2, func(t time.Time) tea.Msg {
-					return resetCopiedMsg{}
-				})
+			if len(m.entries) > 0 {
+				err := CopyToClipboard(m.entries[m.index].Password)
+				if err == nil {
+					m.copied = true
+					return m, tea.Tick(time.Second*2, func(t time.Time) tea.Msg {
+						return resetCopiedMsg{}
+					})
+				}
 			}
 		case "esc", "enter", "q":
 			m.canceled = true
@@ -70,21 +96,39 @@ func (m *PasswordModal) View() string {
 		return ""
 	}
 
+	titleText := "🔑 Connection Password"
+	if len(m.entries) > 1 {
+		titleText = "🔑 Select Password to Copy"
+	}
+
 	title := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(colorPrimary).
-		Render("🔑 Connection Password")
+		Render(titleText)
 
-	passDisplay := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("212")). // Pinkish color for password
-		Bold(true).
-		Render(m.password)
-	
-	if m.password == "" {
-		passDisplay = lipgloss.NewStyle().
-			Foreground(colorInactive).
-			Italic(true).
-			Render("(No password stored)")
+	var content strings.Builder
+	content.WriteString(title + "\n\n")
+
+	for i, entry := range m.entries {
+		style := lipgloss.NewStyle().Foreground(colorSubText)
+		prefix := "  "
+		if i == m.index && len(m.entries) > 1 {
+			style = lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
+			prefix = "> "
+		}
+
+		label := style.Render(prefix + entry.Label + ":")
+		pass := entry.Password
+		if pass == "" {
+			pass = "(empty)"
+		}
+
+		passStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("212")).Bold(true)
+		if i != m.index && len(m.entries) > 1 {
+			passStyle = lipgloss.NewStyle().Foreground(colorInactive)
+		}
+
+		content.WriteString(fmt.Sprintf("%s %s\n", label, passStyle.Render(pass)))
 	}
 
 	copyStatus := " "
@@ -93,29 +137,26 @@ func (m *PasswordModal) View() string {
 			Foreground(lipgloss.Color("42")). // Green
 			Render("✓ Copied to clipboard!")
 	}
+	content.WriteString("\n" + copyStatus + "\n")
+
+	promptText := "Press C to copy, Esc/Enter to close"
+	if len(m.entries) > 1 {
+		promptText = "↑/↓ to select, C to copy, Esc/Enter to close"
+	}
 
 	prompt := lipgloss.NewStyle().
 		Foreground(colorInactive).
-		Render("Press C to copy, Esc/Enter to close")
-
-	content := lipgloss.JoinVertical(lipgloss.Center,
-		title,
-		"\n",
-		passDisplay,
-		"\n",
-		copyStatus,
-		"\n",
-		prompt,
-	)
+		Render(promptText)
+	content.WriteString(prompt)
 
 	// Wrap in a bordered box
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(colorPrimary).
 		Padding(1, 3).
-		Width(50).
+		Width(55).
 		Align(lipgloss.Center).
-		Render(content)
+		Render(content.String())
 
 	// Center on screen
 	return lipgloss.Place(

--- a/internal/ui/components/password_modal.go
+++ b/internal/ui/components/password_modal.go
@@ -1,0 +1,137 @@
+package components
+
+import (
+	"time"
+
+	"github.com/atotto/clipboard"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type PasswordModal struct {
+	password    string
+	copied      bool
+	canceled    bool
+	width       int
+	height      int
+	copyTimeout *time.Timer
+}
+
+type resetCopiedMsg struct{}
+
+func NewPasswordModal(password string) *PasswordModal {
+	return &PasswordModal{
+		password: password,
+	}
+}
+
+func (m *PasswordModal) Init() tea.Cmd {
+	return nil
+}
+
+func CopyToClipboard(text string) error {
+	return clipboard.WriteAll(text)
+}
+
+func (m *PasswordModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.SetSize(msg.Width, msg.Height)
+		return m, nil
+
+	case resetCopiedMsg:
+		m.copied = false
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "c", "C":
+			err := CopyToClipboard(m.password)
+			if err == nil {
+				m.copied = true
+				return m, tea.Tick(time.Second*2, func(t time.Time) tea.Msg {
+					return resetCopiedMsg{}
+				})
+			}
+		case "esc", "enter", "q":
+			m.canceled = true
+			return m, nil
+		case "ctrl+c":
+			m.canceled = true
+			return m, nil
+		}
+	}
+
+	return m, nil
+}
+
+func (m *PasswordModal) View() string {
+	if m.canceled {
+		return ""
+	}
+
+	title := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(colorPrimary).
+		Render("🔑 Connection Password")
+
+	passDisplay := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("212")). // Pinkish color for password
+		Bold(true).
+		Render(m.password)
+	
+	if m.password == "" {
+		passDisplay = lipgloss.NewStyle().
+			Foreground(colorInactive).
+			Italic(true).
+			Render("(No password stored)")
+	}
+
+	copyStatus := " "
+	if m.copied {
+		copyStatus = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("42")). // Green
+			Render("✓ Copied to clipboard!")
+	}
+
+	prompt := lipgloss.NewStyle().
+		Foreground(colorInactive).
+		Render("Press C to copy, Esc/Enter to close")
+
+	content := lipgloss.JoinVertical(lipgloss.Center,
+		title,
+		"\n",
+		passDisplay,
+		"\n",
+		copyStatus,
+		"\n",
+		prompt,
+	)
+
+	// Wrap in a bordered box
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorPrimary).
+		Padding(1, 3).
+		Width(50).
+		Align(lipgloss.Center).
+		Render(content)
+
+	// Center on screen
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		box,
+	)
+}
+
+func (m *PasswordModal) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+func (m *PasswordModal) IsCanceled() bool {
+	return m.canceled
+}

--- a/internal/ui/components/rename_modal.go
+++ b/internal/ui/components/rename_modal.go
@@ -1,0 +1,131 @@
+package components
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type RenameModal struct {
+	textInput   textinput.Model
+	currentName string
+	host        string
+	confirmed   bool
+	canceled    bool
+	width       int
+	height      int
+}
+
+func NewRenameModal(currentName, host string) *RenameModal {
+	ti := textinput.New()
+	ti.SetValue(currentName)
+	ti.Focus()
+	ti.CharLimit = 100
+	ti.Width = 40
+	ti.Prompt = "New Name: "
+	ti.PromptStyle = focusedStyle
+	ti.TextStyle = focusedStyle
+
+	return &RenameModal{
+		textInput:   ti,
+		currentName: currentName,
+		host:        host,
+	}
+}
+
+func (m *RenameModal) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m *RenameModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.SetSize(msg.Width, msg.Height)
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			if m.textInput.Value() != "" {
+				m.confirmed = true
+				return m, nil
+			}
+		case "esc":
+			m.canceled = true
+			return m, nil
+		case "ctrl+c":
+			m.canceled = true
+			return m, nil
+		}
+	}
+
+	var cmd tea.Cmd
+	m.textInput, cmd = m.textInput.Update(msg)
+	return m, cmd
+}
+
+func (m *RenameModal) View() string {
+	if m.canceled {
+		return ""
+	}
+
+	title := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(colorPrimary).
+		Render("✏ Rename Connection")
+
+	details := lipgloss.NewStyle().
+		Foreground(colorSubText).
+		Render(fmt.Sprintf("Current: %s (%s)", m.currentName, m.host))
+
+	prompt := lipgloss.NewStyle().
+		Foreground(colorInactive).
+		Render("Press Enter to confirm, Esc to cancel")
+
+	content := lipgloss.JoinVertical(lipgloss.Center,
+		title,
+		"\n",
+		details,
+		"\n",
+		m.textInput.View(),
+		"\n\n",
+		prompt,
+	)
+
+	// Wrap in a bordered box
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorPrimary).
+		Padding(1, 3).
+		Width(60).
+		Align(lipgloss.Center).
+		Render(content)
+
+	// Center on screen
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		box,
+	)
+}
+
+func (m *RenameModal) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+func (m *RenameModal) IsConfirmed() bool {
+	return m.confirmed
+}
+
+func (m *RenameModal) IsCanceled() bool {
+	return m.canceled
+}
+
+func (m *RenameModal) Value() string {
+	return m.textInput.Value()
+}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -267,8 +267,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch m.state {
 		case StateConnectionList:
 			if m.connectionList != nil {
-				// If delete confirmation is showing, pass ALL keys to connectionList
-				if m.connectionList.IsShowingDeleteConfirm() {
+				// If delete confirmation or password modal is showing, pass ALL keys to connectionList
+				if m.connectionList.IsShowingDeleteConfirm() || m.connectionList.IsShowingPasswordModal() {
 					model, cmd := m.connectionList.Update(msg)
 					m.connectionList = model.(*components.ConnectionList)
 					return m, cmd
@@ -308,6 +308,30 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					model, cmd := m.connectionList.Update(msg)
 					m.connectionList = model.(*components.ConnectionList)
 					return m, cmd
+				case msg.String() == "p" || msg.String() == "P":
+					// Show password modal for highlighted connection
+					if conn := m.connectionList.HighlightedConnection(); conn != nil {
+						// Fetch full connection with password
+						fullConn, ok := m.storageBackend.GetConnection(conn.ID)
+						if ok {
+							m.connectionList.ShowPassword(fullConn.Password)
+							return m, nil
+						}
+					}
+				case msg.String() == "c" || msg.String() == "C":
+					// Copy password directly to clipboard
+					if conn := m.connectionList.HighlightedConnection(); conn != nil {
+						fullConn, ok := m.storageBackend.GetConnection(conn.ID)
+						if ok && fullConn.Password != "" {
+							if err := components.CopyToClipboard(fullConn.Password); err == nil {
+								m.errorMessage = "Password copied to clipboard!"
+								return m, nil
+							}
+						} else if ok && fullConn.Password == "" {
+							m.errorMessage = "No password stored for this connection"
+							return m, nil
+						}
+					}
 				case msg.String() == "s":
 					// Open SCP file manager
 					if selectedItem := m.connectionList.HighlightedConnection(); selectedItem != nil {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/eugeniofciuvasile/ssh-x-term/internal/config"
 	"github.com/eugeniofciuvasile/ssh-x-term/internal/ui/components"
 )
 
@@ -160,6 +161,170 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case components.RenameConnectionMsg:
+		if m.storageBackend != nil {
+			msg.Connection.Name = msg.NewName
+			if err := m.storageBackend.EditConnection(msg.Connection); err != nil {
+				m.errorMessage = fmt.Sprintf("Failed to rename: %s", err)
+				return m, nil
+			}
+			conns := m.storageBackend.ListConnections()
+			m.connectionList.SetConnections(conns)
+			return m, nil
+		}
+		return m, nil
+
+	case components.TogglePinnedMsg:
+		if m.storageBackend != nil {
+			msg.Connection.Pinned = !msg.Connection.Pinned
+			if err := m.storageBackend.EditConnection(msg.Connection); err != nil {
+				m.errorMessage = fmt.Sprintf("Failed to pin connection: %s", err)
+				return m, nil
+			}
+			
+			// Refresh list from backend to get latest state
+			conns := m.storageBackend.ListConnections()
+			m.connectionList.SetConnections(conns)
+			
+			// Try to find the new index of the toggled connection to keep it highlighted
+			newIdx := 0
+			for i, c := range m.connectionList.Connections {
+				if c.ID == msg.Connection.ID {
+					newIdx = i
+					break
+				}
+			}
+			m.connectionList.List().Select(newIdx)
+			
+			return m, nil
+		}
+		return m, nil
+
+	case components.MoveConnectionUpMsg:
+		if m.storageBackend != nil {
+			conns := m.storageBackend.ListConnections()
+			currentSorted := m.connectionList.Connections
+			idx := -1
+			for i, c := range currentSorted {
+				if c.ID == msg.Connection.ID {
+					idx = i
+					break
+				}
+			}
+
+			if idx > 0 {
+				above := currentSorted[idx-1]
+				// Only allow swapping within the same Pinned status
+				if msg.Connection.Pinned != above.Pinned {
+					return m, nil
+				}
+
+				// Find both in the backend list to swap their Order
+				var connInBackend, aboveInBackend *config.SSHConnection
+				for i := range conns {
+					if conns[i].ID == msg.Connection.ID {
+						connInBackend = &conns[i]
+					} else if conns[i].ID == above.ID {
+						aboveInBackend = &conns[i]
+					}
+				}
+
+				if connInBackend != nil && aboveInBackend != nil {
+					// Swap orders
+					connInBackend.Order, aboveInBackend.Order = aboveInBackend.Order, connInBackend.Order
+					
+					// If orders were equal (default 0), we need to initialize them properly
+					if connInBackend.Order == aboveInBackend.Order {
+						// Assign orders based on current list position to everything
+						for i := range conns {
+							for j, sc := range currentSorted {
+								if conns[i].ID == sc.ID {
+									conns[i].Order = j
+								}
+							}
+						}
+						// Now swap the two we want
+						for i := range conns {
+							if conns[i].ID == msg.Connection.ID {
+								conns[i].Order = idx - 1
+							} else if conns[i].ID == above.ID {
+								conns[i].Order = idx
+							}
+						}
+					}
+
+					// Save both
+					_ = m.storageBackend.EditConnection(*connInBackend)
+					_ = m.storageBackend.EditConnection(*aboveInBackend)
+
+					// Update UI model directly to avoid reload flicker and maintain selection
+					m.connectionList.SetConnections(conns)
+					m.connectionList.List().Select(idx - 1)
+					return m, nil
+				}
+			}
+		}
+		return m, nil
+
+	case components.MoveConnectionDownMsg:
+		if m.storageBackend != nil {
+			conns := m.storageBackend.ListConnections()
+			currentSorted := m.connectionList.Connections
+			idx := -1
+			for i, c := range currentSorted {
+				if c.ID == msg.Connection.ID {
+					idx = i
+					break
+				}
+			}
+
+			if idx >= 0 && idx < len(currentSorted)-1 {
+				below := currentSorted[idx+1]
+				// Only allow swapping within the same Pinned status
+				if msg.Connection.Pinned != below.Pinned {
+					return m, nil
+				}
+
+				var connInBackend, belowInBackend *config.SSHConnection
+				for i := range conns {
+					if conns[i].ID == msg.Connection.ID {
+						connInBackend = &conns[i]
+					} else if conns[i].ID == below.ID {
+						belowInBackend = &conns[i]
+					}
+				}
+
+				if connInBackend != nil && belowInBackend != nil {
+					connInBackend.Order, belowInBackend.Order = belowInBackend.Order, connInBackend.Order
+					
+					if connInBackend.Order == belowInBackend.Order {
+						for i := range conns {
+							for j, sc := range currentSorted {
+								if conns[i].ID == sc.ID {
+									conns[i].Order = j
+								}
+							}
+						}
+						for i := range conns {
+							if conns[i].ID == msg.Connection.ID {
+								conns[i].Order = idx + 1
+							} else if conns[i].ID == below.ID {
+								conns[i].Order = idx
+							}
+						}
+					}
+
+					_ = m.storageBackend.EditConnection(*connInBackend)
+					_ = m.storageBackend.EditConnection(*belowInBackend)
+
+					m.connectionList.SetConnections(conns)
+					m.connectionList.List().Select(idx + 1)
+					return m, nil
+				}
+			}
+		}
+		return m, nil
+
 	case LoadConnectionsFinishedMsg:
 		m.loading = false // finally stop the spinner here
 		if msg.Err != nil {
@@ -267,8 +432,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch m.state {
 		case StateConnectionList:
 			if m.connectionList != nil {
-				// If delete confirmation or password modal is showing, pass ALL keys to connectionList
-				if m.connectionList.IsShowingDeleteConfirm() || m.connectionList.IsShowingPasswordModal() {
+				// If delete confirmation, password modal or rename modal is showing, pass ALL keys to connectionList
+				if m.connectionList.IsShowingDeleteConfirm() || m.connectionList.IsShowingPasswordModal() || m.connectionList.IsShowingRenameModal() {
 					model, cmd := m.connectionList.Update(msg)
 					m.connectionList = model.(*components.ConnectionList)
 					return m, cmd
@@ -303,6 +468,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.state = StateEditConnection
 						return m, m.connectionForm.Init()
 					}
+				case msg.String() == "r":
+					// Rename connection
+					m.connectionList.ShowRename()
+					return m, nil
 				case msg.String() == "d" || msg.String() == "D":
 					// Pass to connectionList for delete confirmation handling
 					model, cmd := m.connectionList.Update(msg)
@@ -314,22 +483,55 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						// Fetch full connection with password
 						fullConn, ok := m.storageBackend.GetConnection(conn.ID)
 						if ok {
-							m.connectionList.ShowPassword(fullConn.Password)
+							m.connectionList.ShowPassword(fullConn)
 							return m, nil
 						}
 					}
+				case msg.String() == "f":
+					// Pin/Unpin connection
+					return m, m.connectionList.TogglePinned()
+				case msg.String() == "K":
+					// Move connection up
+					return m, m.connectionList.MoveUp()
+				case msg.String() == "J":
+					// Move connection down
+					return m, m.connectionList.MoveDown()
 				case msg.String() == "c" || msg.String() == "C":
-					// Copy password directly to clipboard
+					// Copy password directly or show modal if multiple
 					if conn := m.connectionList.HighlightedConnection(); conn != nil {
 						fullConn, ok := m.storageBackend.GetConnection(conn.ID)
-						if ok && fullConn.Password != "" {
-							if err := components.CopyToClipboard(fullConn.Password); err == nil {
-								m.errorMessage = "Password copied to clipboard!"
+						if ok {
+							count := 0
+							var lastPass, lastLabel string
+							
+							if fullConn.Password != "" {
+								count++
+								lastPass = fullConn.Password
+								lastLabel = "Password"
+								if !fullConn.UsePassword {
+									lastLabel = "Key Passphrase"
+								}
+							}
+							if fullConn.SudoPassword != "" {
+								count++
+								lastPass = fullConn.SudoPassword
+								lastLabel = "Sudo Password"
+							}
+
+							if count > 1 {
+								// Multiple passwords, show modal for selection
+								m.connectionList.ShowPassword(fullConn)
+								return m, nil
+							} else if count == 1 {
+								// Only one password, copy it directly
+								if err := components.CopyToClipboard(lastPass); err == nil {
+									m.errorMessage = lastLabel + " copied to clipboard!"
+									return m, nil
+								}
+							} else {
+								m.errorMessage = "No password stored for this connection"
 								return m, nil
 							}
-						} else if ok && fullConn.Password == "" {
-							m.errorMessage = "No password stored for this connection"
-							return m, nil
 						}
 					}
 				case msg.String() == "s":

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -160,7 +160,7 @@ func (m *Model) getHelpText() string {
 
 	switch m.state {
 	case StateConnectionList:
-		return "a: add | e: edit | d: delete | p: password | c: copy | s: scp | / filter | o: toggle new terminal | enter: connect | ctrl+c: quit"
+		return "a: add | e: edit | d: delete | f: pin | K/J: move | r: rename | p: pass | c: copy | s: scp | / filter | o: toggle new terminal | enter: connect | ctrl+c: quit"
 	case StateSSHTerminal:
 		if m.terminal != nil {
 			if m.terminal.IsSessionClosed() {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -160,7 +160,7 @@ func (m *Model) getHelpText() string {
 
 	switch m.state {
 	case StateConnectionList:
-		return "a: add | e: edit | d: delete | s: scp | / filter | o: toggle new terminal | enter: connect | ctrl+c: quit"
+		return "a: add | e: edit | d: delete | p: password | c: copy | s: scp | / filter | o: toggle new terminal | enter: connect | ctrl+c: quit"
 	case StateSSHTerminal:
 		if m.terminal != nil {
 			if m.terminal.IsSessionClosed() {


### PR DESCRIPTION
This pull request adds support for new SSH connection metadata fields (`sudo_password`, `pinned`, and `order`) and ensures secure handling of the `sudo_password` using the system keyring. It also updates the UI to support pinning, ordering, and renaming connections, and includes improvements to sorting and rendering in the connection list.

**Secure handling of sudo password:**
- Added `SudoPassword` field to `SSHConnection` and updated all config managers (`config.go`, `sshconfig.go`) to store, retrieve, and delete `sudo_password` securely using the system keyring, avoiding plaintext storage. This includes migration support and test coverage.

**Support for pinning and ordering connections:**
- Added `Pinned` (bool) and `Order` (int) fields to `SSHConnection` and updated parsing, serialization, and UI display logic to support pinning and manual ordering of connections. Connections are now sorted by pinned status, order, and name.

**Bitwarden integration enhancements:**
- Updated Bitwarden manager to handle the new fields (`sudo_password`, `pinned`, `order`) during load, add, and edit operations, ensuring these attributes are synced with Bitwarden items.

**UI and interaction improvements:**
- Enhanced the connection list component to display pinned connections with an icon, support renaming, pin/unpin, and moving connections up/down, and sort connections based on the new fields. Added new message types for these actions.

**Testing and migration:**
- Updated tests to verify that the `sudo_password` is correctly stored and retrieved using the keyring, and ensured migration from legacy config/keyring includes the new field.